### PR TITLE
site: footer launch badges (Product Hunt + DevHunt)

### DIFF
--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -114,12 +114,6 @@
       </a>
     </div>
 
-    <!-- Product Hunt badge -->
-    <div class="mt-8 flex justify-center">
-      <a href="https://www.producthunt.com/products/avai-you-ai-anti-virus-scanner?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-avai-you-ai-anti-virus-scanner" target="_blank" rel="noopener noreferrer">
-        <img alt="avai - you AI anti virus scanner - There's a copilot for your code. Why not for your machine? | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1159062&theme=light&t=1780105838964">
-      </a>
-    </div>
 
     <!-- ticker -->
     <div class="mt-10 grid grid-cols-2 md:grid-cols-4 gap-3 max-w-3xl mx-auto text-sm">
@@ -595,9 +589,18 @@ avai dashboard</pre>
 
 <!-- footer -->
 <footer class="border-t border-white/5">
+  <!-- launch badges -->
+  <div class="max-w-6xl mx-auto px-6 pt-10 flex flex-wrap items-center justify-center gap-6">
+    <a href="https://www.producthunt.com/products/avai-you-ai-anti-virus-scanner?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-avai-you-ai-anti-virus-scanner" target="_blank" rel="noopener noreferrer">
+      <img alt="avai - you AI anti virus scanner - There's a copilot for your code. Why not for your machine? | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1159062&theme=light&t=1780105838964">
+    </a>
+    <!-- DevHunt badge -->
+    <script defer data-url="https://devhunt.org/tool/avai" src="https://cdn.jsdelivr.net/gh/sidiDev/devhunt-banner/indexV0.js"></script>
+  </div>
+
   <div class="max-w-6xl mx-auto px-6 py-10 flex flex-col md:flex-row items-center justify-between gap-4 text-sm text-slate-500">
     <div class="flex items-center gap-2">
-      <span class="mono inline-flex items-center justify-center w-6 h-6 rounded bg-slate-900 ring-1 ring-emerald-400/30 text-emerald-300 text-xs font-bold">a</span>
+      <img src="/assets/logo.png" alt="avai logo" class="w-6 h-6 rounded ring-1 ring-white/10 object-cover" />
       <span class="mono">avai</span>
       <span>·</span>
       <span>MIT</span>


### PR DESCRIPTION
Moves the Product Hunt badge from the hero into a footer **launch badges** row and adds the DevHunt banner script alongside it (as requested). Footer 'a' mark swapped for the logo for consistency.