### PR TITLE
fix: mobile responsive overflow - verdict totals + tables

### DIFF
--- a/src/avai/templates/dashboard.html
+++ b/src/avai/templates/dashboard.html
@@ -37,6 +37,15 @@
       -webkit-box-orient: vertical;
       overflow: hidden;
     }
+    /* responsive tables — scroll horizontally on narrow screens */
+    @media (max-width: 767px) {
+      table {
+        display: block;
+        overflow-x: auto;
+        white-space: nowrap;
+        -webkit-overflow-scrolling: touch;
+      }
+    }
   </style>
 </head>
 <body class="bg-slate-950 text-slate-200 font-sans antialiased min-h-screen">

--- a/src/avai/templates/partials/_overview.html
+++ b/src/avai/templates/partials/_overview.html
@@ -31,10 +31,10 @@
   'benign':     verdict_counts.get('benign',     0),
 } %}
 {% set vc_total = vc.values() | sum %}
-<div class="bg-slate-900 border border-slate-800 rounded-lg p-5">
+<div class="bg-slate-900 border border-slate-800 rounded-lg p-4 sm:p-5">
   <div class="text-[10px] uppercase tracking-widest text-slate-500 mb-3">verdict totals</div>
-  <div class="flex items-center gap-4">
-    <div class="relative w-20 h-20 flex-shrink-0">
+  <div class="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
+    <div class="relative w-16 h-16 sm:w-20 sm:h-20 flex-shrink-0 mx-auto sm:mx-0">
       <canvas id="verdict-donut"
               class="js-verdict-donut"
               data-malicious="{{ vc.malicious }}"


### PR DESCRIPTION
# Description
Two changes in here to make the dashboard mobile friendly. Before the cards and tables were overflowing off the side of the screen. I've added some responsiveness, while leaving existing classes in place for screens bigger than "small"

Donut chart and legend now stack vertically instead of squeezing side by side. On the "Verdict totals" card:
## Before
<img width="1206" height="938" alt="Image" src="https://github.com/user-attachments/assets/fdbdf6bb-2721-4ee5-a844-39ec54fc50ce" />

## After
<img width="1206" height="1135" alt="Image" src="https://github.com/user-attachments/assets/1993770c-5dd4-4aa0-bae8-7de038d0b52c" />

---
For all tables, use a media query to make every table horizontally scrollable instead of overflowing out the sides of their parent cards:

## Before
<img width="1206" height="455" alt="IMG_5786" src="https://github.com/user-attachments/assets/38fa882c-fe24-48e1-a41a-5bb3a2f3bbc1" />

## After
Hard to tell but this is now scrollable
<img width="1206" height="286" alt="IMG_5787" src="https://github.com/user-attachments/assets/216b3a4a-24bf-4af0-ac84-5b9c4109c682" />
