### PR TITLE
site: add Soro blog embed to landing page

### DIFF
--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -69,6 +69,7 @@
       <a href="#features" class="hover:text-slate-100 transition">Features</a>
       <a href="#why" class="hover:text-slate-100 transition">Why avai</a>
       <a href="#install" class="hover:text-slate-100 transition">Get started</a>
+      <a href="#blog" class="hover:text-slate-100 transition">Blog</a>
       <a href="/docs/" class="hover:text-slate-100 transition">Docs</a>
       <a href="https://github.com/iklobato/avai" class="hover:text-slate-100 transition">GitHub →</a>
     </nav>
@@ -794,6 +795,21 @@ avai dashboard</pre>
   </div>
 </section>
 
+<section id="blog" class="border-t border-white/5 bg-black/20">
+  <div class="max-w-6xl mx-auto px-6 py-20">
+    <div class="text-center max-w-2xl mx-auto">
+      <div class="text-emerald-400 text-xs uppercase tracking-widest font-medium">Blog</div>
+      <h2 class="mt-3 text-3xl md:text-4xl font-semibold text-slate-100 tracking-tight">
+        From the blog.
+      </h2>
+      <p class="mt-4 text-slate-400">
+        Notes on what avai checks, why it matters, and how to read your results.
+      </p>
+    </div>
+    <div id="soro-blog" class="mt-12"></div>
+  </div>
+</section>
+
 <!-- footer -->
 <footer class="border-t border-white/5">
   <!-- launch badges -->
@@ -821,6 +837,9 @@ avai dashboard</pre>
     </div>
   </div>
 </footer>
+
+<!-- Soro blog embed (renders into #soro-blog above) -->
+<script src="https://app.trysoro.com/api/embed/bd68eb65-c4c0-4180-88e9-4b69fde0944c" defer></script>
 
 </body>
 </html>


### PR DESCRIPTION
Adds a Blog section (`#blog`) before the footer on the landing page with the trysoro embed mount point and loader script, plus a nav link.

- New `#blog` section matching existing section styling
- Nav link "Blog" between "Get started" and "Docs"
- Soro embed script loaded `defer` before `</body>`
- Only `landing-page/index.html` touched