### PR TITLE
fix(ci): rate-limiter first-call bug + gate Linux-only tests on Windows

### DIFF
--- a/src/avai/enrichers/http.py
+++ b/src/avai/enrichers/http.py
@@ -41,7 +41,13 @@ class _TokenBucket:
 
     def __init__(self, rate_per_second: float):
         self._period = 1.0 / max(rate_per_second, 0.01)
-        self._last = 0.0
+        # The bucket starts full: the first take() must never wait. ``0.0``
+        # is wrong because ``time.monotonic()`` counts from an arbitrary
+        # epoch (system uptime on Linux) — on a low-uptime host where
+        # ``monotonic() < period`` the first call would sleep up to a full
+        # period (hours for a slow source). ``-inf`` makes the first wait
+        # unconditionally negative, then real pacing kicks in from take().
+        self._last = float("-inf")
         self._lock = threading.Lock()
 
     def take(self) -> None:

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -15,6 +15,7 @@ was in `HostPaths.for_home()` returning [] and the caller doing
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -23,11 +24,21 @@ import avai.host_monitor as hm
 from avai.host_monitor import LinuxLaunchItemsCollector
 from avai.host_monitor.runtime import HostPaths
 
+# HOST_PREFIX path translation, the Linux launch_items collector, and the
+# journald-dir probe all assume POSIX path semantics and a Linux filesystem
+# layout (forward-slash joins, /etc, systemd unit dirs). On Windows
+# pathlib produces backslash WindowsPaths and the assertions don't hold —
+# the behaviour under test never runs there, so these classes are skipped.
+_linux_only = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX path / Linux collector behaviour"
+)
+
 # ---------------------------------------------------------------------------
 # host_path — absolute-path translation under HOST_PREFIX
 # ---------------------------------------------------------------------------
 
 
+@_linux_only
 class TestHostPath:
     def test_passthrough_without_prefix(self, monkeypatch):
         monkeypatch.setattr(hm.constants, "HOST_PREFIX", "")
@@ -48,6 +59,7 @@ class TestHostPath:
 # ---------------------------------------------------------------------------
 
 
+@_linux_only
 class TestHostPathsForHome:
     def test_absolute_template_returns_single_translated_path(self, monkeypatch):
         monkeypatch.setattr(hm.constants, "HOST_PREFIX", "/host")
@@ -105,6 +117,7 @@ def _write_unit(prefix: Path, rel_dir: str, name: str, body: str) -> None:
     (d / name).write_text(body, encoding="utf-8")
 
 
+@_linux_only
 class TestLinuxLaunchItemsCollect:
     def test_does_not_crash_when_no_home_or_root_mounted(self, tmp_path, monkeypatch):
         """THE regression test. Container mode with HOST_PREFIX set but
@@ -281,6 +294,7 @@ class TestCronRows:
 # ---------------------------------------------------------------------------
 
 
+@_linux_only
 class TestLinuxAuthEventsJournalDir:
     def _directory_arg(self, cmd):
         return cmd[cmd.index("--directory") + 1] if "--directory" in cmd else None
@@ -307,7 +321,9 @@ class TestLinuxAuthEventsJournalDir:
         cmd = hm.LinuxAuthEventsCollector()._cmd()
         assert self._directory_arg(cmd) == str(runtime)
 
-    def test_no_directory_flag_when_no_host_journal_present(self, monkeypatch, tmp_path):
+    def test_no_directory_flag_when_no_host_journal_present(
+        self, monkeypatch, tmp_path
+    ):
         monkeypatch.setattr(hm.constants, "HOST_PREFIX", str(tmp_path))
         cmd = hm.LinuxAuthEventsCollector()._cmd()
         assert "--directory" not in cmd

--- a/tests/test_disk_container.py
+++ b/tests/test_disk_container.py
@@ -11,7 +11,10 @@ and the three modes (native / container-no-rootfs / container-rootfs).
 
 from __future__ import annotations
 
+import sys
 from collections import namedtuple
+
+import pytest
 
 import avai.host_monitor.constants as constants
 from avai.host_monitor.runtime import probes
@@ -21,6 +24,15 @@ from avai.host_monitor.runtime.probes import (
     _parse_mounts,
     _statvfs_usage,
     _unescape_mount_field,
+)
+
+# DiskMetrics container mode is Linux-specific: it parses /proc-style mount
+# tables and measures filesystems via os.statvfs (absent on Windows) through
+# the $HOST_PREFIX/rootfs mount. None of it runs on Windows, so the suite
+# would only fail there on an AttributeError, not a real regression.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Linux container disk-metrics; no os.statvfs on Windows",
 )
 
 


### PR DESCRIPTION
Fixes the red CI on main after #12 — both failures pre-existing and unrelated to the v0.6.0 feature work.

## 1. Production bug: rate-limiter first call could block for ~period
`_TokenBucket._last` was `0.0`, but `time.monotonic()` counts from an arbitrary epoch (uptime on Linux). On a low-uptime host (`monotonic() < period`) the **first** request to a rate-limited host slept up to a full period — hours for a 0.0001 rps source. Dev machines masked it; a low-uptime CI runner exposed it (ubuntu py3.12 flake). Fix: init `_last = -inf` so the first `take()` never waits. Verified under a simulated low-monotonic clock.

## 2. Gate Linux-only tests on Windows
`test_disk_container.py` uses `os.statvfs` (absent on Windows); `test_collectors.py` HOST_PREFIX / Linux launch-items / journald classes assume POSIX paths. That code never runs on Windows, so skip those on `win32` — the Windows CI leg still exercises the cross-platform suite.

## Verify
734 pass locally; ruff clean; first-call-free proven under simulated low uptime.