### PR TITLE
feat(scan): support Neo23x0/signature-base rules via YARA externals

### DIFF
--- a/scripts/update_rules.py
+++ b/scripts/update_rules.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
-"""Fetch a pinned YARA-Forge "core" rule pack into src/avai/rules/vendor/.
+"""Fetch a pinned, opt-in YARA rule pack into src/avai/rules/vendor/<source>/.
 
-Pulls an exact, pinned upstream release (reproducible) and extracts its
-``.yar`` / ``.yara`` files plus the upstream LICENSE/attribution into the
-vendor directory, which the FileScanCollector then compiles alongside the
-bundled baseline rules.
+The FileScanCollector compiles every ``*.yar`` / ``*.yara`` it finds under
+the rules dir, so a fetched pack is picked up automatically. Packs are
+NOT committed and NOT shipped in the wheel (see src/avai/rules/NOTICE);
+they're opt-in per environment. Stdlib only; no third-party deps.
 
-The pack is intentionally not committed to the repo by default — see
-src/avai/rules/NOTICE for the licensing sign-off this requires. Stdlib
-only; no third-party deps.
+    python scripts/update_rules.py                       # signature-base (default)
+    python scripts/update_rules.py --source yara-forge   # YARA-Forge core
+    python scripts/update_rules.py --ref <sha-or-tag>    # override the pin
 
-    python scripts/update_rules.py                  # fetch the pinned release
-    python scripts/update_rules.py --version 20250901   # bump the pin
+signature-base rules need a crypto-enabled yara for the imphash/hash.*
+rules; the rest compile on the stock PyPI wheel (the collector skips the
+uncompilable files individually). See src/avai/rules/NOTICE.
 """
 
 from __future__ import annotations
@@ -19,48 +20,104 @@ from __future__ import annotations
 import argparse
 import io
 import sys
+import tarfile
 import urllib.request
 import zipfile
 from pathlib import Path
 
-# Pinned YARA-Forge release (tags are date-stamped YYYYMMDD). Bump
-# deliberately (and re-run the licensing review) rather than tracking
-# "latest".
-DEFAULT_VERSION = "20260614"
-ASSET = "yara-forge-rules-core.zip"
-_URL = "https://github.com/YARAHQ/yara-forge/releases/download/{version}/" + ASSET
-
 _RULES_DIR = Path(__file__).resolve().parent.parent / "src" / "avai" / "rules"
 _VENDOR_DIR = _RULES_DIR / "vendor"
-
 _RULE_SUFFIXES = (".yar", ".yara")
-_KEEP_ALSO = ("license", "notice", "readme")  # attribution files, lowercased stem match
+_ATTRIBUTION_STEMS = ("license", "notice", "readme")  # lowercased stem match
 
 
-def _download(version: str) -> bytes:
-    url = _URL.format(version=version)
+# Each source pins an exact upstream ref for reproducibility. Bump a pin
+# deliberately (and re-check attribution) rather than tracking "latest".
+class _Source:
+    def __init__(self, name, url, archive, ref, member_filter):
+        self.name = name
+        self.url = url  # may contain {ref}
+        self.archive = archive  # "zip" | "tar.gz"
+        self.ref = ref
+        self.member_filter = member_filter  # (member_name) -> bool
+
+
+def _signature_base_member(name: str) -> bool:
+    # Keep yara/*.yar|*.yara rules and the top-level LICENSE for attribution.
+    p = Path(name)
+    if "/yara/" in name and p.suffix.lower() in _RULE_SUFFIXES:
+        return True
+    return p.stem.lower() in _ATTRIBUTION_STEMS and p.suffix.lower() in (
+        "",
+        ".txt",
+        ".md",
+    )
+
+
+def _yara_forge_member(name: str) -> bool:
+    p = Path(name)
+    return p.suffix.lower() in _RULE_SUFFIXES or p.stem.lower() in _ATTRIBUTION_STEMS
+
+
+SOURCES = {
+    # Florian Roth's signature-base — individual .yar files, DRL 1.1 (permits
+    # MIT bundling with attribution). Fetched as a tarball at a pinned commit.
+    "signature-base": _Source(
+        name="signature-base",
+        url="https://github.com/Neo23x0/signature-base/archive/{ref}.tar.gz",
+        archive="tar.gz",
+        ref="3b78d4102c12e6059ff71a6157909f1e4d3e3450",  # 2026-06-15
+        member_filter=_signature_base_member,
+    ),
+    # YARA-Forge "core" — one consolidated .yar, mixed-license (needs a
+    # sign-off before committing). Released as a date-stamped zip.
+    "yara-forge": _Source(
+        name="yara-forge",
+        url="https://github.com/YARAHQ/yara-forge/releases/download/{ref}/yara-forge-rules-core.zip",
+        archive="zip",
+        ref="20260614",
+        member_filter=_yara_forge_member,
+    ),
+}
+
+
+def _download(url: str) -> bytes:
     print(f"fetching {url}")
     req = urllib.request.Request(url, headers={"User-Agent": "avai-update-rules"})
-    with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310 (pinned host)
+    with urllib.request.urlopen(req, timeout=180) as resp:  # noqa: S310 (pinned host)
         return resp.read()
 
 
-def _extract(blob: bytes, dest: Path) -> int:
-    dest.mkdir(parents=True, exist_ok=True)
+def _safe_target(dest: Path, member_name: str) -> Path:
+    """Flatten a member to ``dest/<basename>``, refusing empty / traversal
+    names (zip-slip / tar-slip)."""
+    base = Path(member_name).name
+    if not base or base in (".", ".."):
+        raise ValueError(f"unsafe member name: {member_name!r}")
+    return dest / base
+
+
+def _extract_zip(blob: bytes, dest: Path, keep) -> int:
     written = 0
     with zipfile.ZipFile(io.BytesIO(blob)) as zf:
-        for member in zf.namelist():
-            name = Path(member).name
-            if not name:
+        for name in zf.namelist():
+            if name.endswith("/") or not keep(name):
                 continue
-            stem = Path(name).stem.lower()
-            is_rule = Path(name).suffix.lower() in _RULE_SUFFIXES
-            is_attribution = any(k in stem for k in _KEEP_ALSO)
-            if not (is_rule or is_attribution):
+            _safe_target(dest, name).write_bytes(zf.read(name))
+            written += 1
+    return written
+
+
+def _extract_tar_gz(blob: bytes, dest: Path, keep) -> int:
+    written = 0
+    with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tf:
+        for member in tf.getmembers():
+            if not member.isfile() or not keep(member.name):
                 continue
-            # Flatten into dest; never honour absolute or parent paths (zip-slip).
-            target = dest / name
-            target.write_bytes(zf.read(member))
+            src = tf.extractfile(member)
+            if src is None:
+                continue
+            _safe_target(dest, member.name).write_bytes(src.read())
             written += 1
     return written
 
@@ -68,18 +125,29 @@ def _extract(blob: bytes, dest: Path) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--version", default=DEFAULT_VERSION, help="YARA-Forge release tag"
+        "--source",
+        choices=sorted(SOURCES),
+        default="signature-base",
+        help="which rule pack to fetch (default: signature-base)",
     )
+    parser.add_argument("--ref", help="override the pinned commit/tag")
     args = parser.parse_args()
 
+    source = SOURCES[args.source]
+    ref = args.ref or source.ref
+    dest = _VENDOR_DIR / source.name
+    dest.mkdir(parents=True, exist_ok=True)
+
     try:
-        blob = _download(args.version)
+        blob = _download(source.url.format(ref=ref))
     except OSError as exc:
         print(f"download failed: {exc}", file=sys.stderr)
         return 1
-    count = _extract(blob, _VENDOR_DIR)
-    print(f"wrote {count} file(s) to {_VENDOR_DIR}")
-    print("Review licensing (src/avai/rules/NOTICE) before committing vendor/.")
+
+    extractor = _extract_tar_gz if source.archive == "tar.gz" else _extract_zip
+    count = extractor(blob, dest, source.member_filter)
+    print(f"wrote {count} file(s) to {dest}")
+    print("Opt-in pack: not committed, not shipped. See src/avai/rules/NOTICE.")
     return 0
 
 

--- a/src/avai/host_monitor/collectors.py
+++ b/src/avai/host_monitor/collectors.py
@@ -26,6 +26,11 @@ except ImportError:
 
 import yara
 
+try:
+    import pwd  # POSIX only; used to resolve file owner for YARA externals
+except ImportError:  # pragma: no cover - Windows has no pwd module
+    pwd = None
+
 from . import constants
 from .constants import (
     APP_INFO_KEYS,
@@ -1269,12 +1274,57 @@ def _crypto_hint(exc: "yara.Error") -> str:
     this yara build lacks OpenSSL (the PyPI wheel does) — pe.imphash() /
     hash.* then read as 'invalid field name'. Empty for any other error."""
     msg = str(exc).lower()
-    if "imphash" in msg or ("invalid field name" in msg and "md5" in msg):
+    _hashish = ("md5", "sha1", "sha256", "checksum", "imphash")
+    if "imphash" in msg or (
+        "invalid field name" in msg and any(h in msg for h in _hashish)
+    ):
         return (
             " — these rules need a crypto-enabled yara (pe.imphash / hash.*);"
             " the PyPI yara-python wheel is built without it. See"
             " avai/rules/NOTICE."
         )
+    return ""
+
+
+# External variables that LOKI / THOR (and thus the signature-base rules)
+# expect. Defined at compile time with empty placeholders so rules that
+# reference them compile; the real per-file values are supplied at match
+# time (see FileScanCollector._match_externals). Without these, many
+# signature-base rules fail to compile with "undefined identifier".
+_YARA_EXTERNALS = {
+    "filename": "",
+    "filepath": "",
+    "extension": "",
+    "filetype": "",
+    "md5": "",
+    "owner": "",
+}
+
+
+def _file_type(path: Path) -> str:
+    """Best-effort ``filetype`` external from leading magic bytes, using the
+    labels signature-base rules compare against. Only the structural binary
+    types are detected reliably (EXE/ELF/MACH-O/MDMP); LOKI's content-derived
+    script labels (Python/PHP/VBS/…) are left empty rather than guessed."""
+    try:
+        with open(path, "rb") as f:
+            head = f.read(8)
+    except OSError:
+        return ""
+    if head[:2] == b"MZ":
+        return "EXE"
+    if head[:4] == b"\x7fELF":
+        return "ELF"
+    if head[:4] in (
+        b"\xfe\xed\xfa\xce",
+        b"\xce\xfa\xed\xfe",
+        b"\xfe\xed\xfa\xcf",
+        b"\xcf\xfa\xed\xfe",
+        b"\xca\xfe\xba\xbe",
+    ):
+        return "MACH-O"
+    if head[:4] == b"MDMP":
+        return "MDMP"
     return ""
 
 
@@ -1284,9 +1334,12 @@ def _compile_yara_rules(rules_dir: Path):
     holds no compilable rules.
 
     Each file is validated independently first and uncompilable ones are
-    skipped with a warning, so a single malformed rule in a bundled pack
-    can't disable scanning entirely. Per-file namespaces keep rule
-    identifiers from colliding across files in the combined compile.
+    skipped with a warning, so a single malformed rule in a fetched pack
+    can't disable scanning entirely (signature-base's per-file layout makes
+    this graceful: only the imphash/hash.* files skip on a crypto-less
+    yara). Per-file namespaces keep rule identifiers from colliding across
+    files. ``_YARA_EXTERNALS`` is supplied so rules referencing scanner
+    externals (filename/filepath/extension/filetype/…) compile.
     """
     if not rules_dir.is_dir():
         return None
@@ -1295,7 +1348,7 @@ def _compile_yara_rules(rules_dir: Path):
         if path.suffix.lower() not in (".yar", ".yara") or not path.is_file():
             continue
         try:
-            yara.compile(filepath=str(path))
+            yara.compile(filepath=str(path), externals=_YARA_EXTERNALS)
         except yara.Error as exc:
             constants.LOG.warning(
                 "yara: skipping uncompilable rules %s: %s%s",
@@ -1314,7 +1367,7 @@ def _compile_yara_rules(rules_dir: Path):
     if not filepaths:
         return None
     try:
-        return yara.compile(filepaths=filepaths)
+        return yara.compile(filepaths=filepaths, externals=_YARA_EXTERNALS)
     except yara.Error as exc:
         constants.LOG.warning("yara: combined compile failed: %s", exc)
         return None
@@ -1437,7 +1490,11 @@ class FileScanCollector(SnapshotCollector):
         if st.st_size > constants.YARA_MAX_FILE_BYTES:
             return
         try:
-            matches = rules.match(str(path), timeout=constants.YARA_MATCH_TIMEOUT_S)
+            matches = rules.match(
+                str(path),
+                externals=self._match_externals(path, st),
+                timeout=constants.YARA_MATCH_TIMEOUT_S,
+            )
         except yara.Error:
             # Unreadable, vanished mid-scan, or match timeout — skip this
             # file and keep scanning the rest.
@@ -1452,10 +1509,34 @@ class FileScanCollector(SnapshotCollector):
                 "rule": m.rule,
                 "namespace": m.namespace,
                 "tags_json": json.dumps(list(m.tags)),
+                # Rule meta (author/reference/description) — retained on the
+                # finding to satisfy the signature-base DRL attribution
+                # obligation and to give the judge/dashboard rule context.
+                "meta_json": json.dumps(m.meta, default=str),
                 "size": st.st_size,
                 "mtime": st.st_mtime,
                 "scan_source": source,
             }
+
+    @staticmethod
+    def _match_externals(path: Path, st) -> dict:
+        """Per-file values for the scanner externals signature-base rules
+        read. ``md5`` is intentionally empty — no rule compares it — so no
+        per-file hashing is forced just to populate an unused variable."""
+        owner = ""
+        if pwd is not None:
+            try:
+                owner = pwd.getpwuid(st.st_uid).pw_name
+            except (KeyError, OSError):
+                owner = ""
+        return {
+            "filename": path.name,
+            "filepath": str(path),
+            "extension": path.suffix.lower(),
+            "filetype": _file_type(path),
+            "md5": "",
+            "owner": owner,
+        }
 
 
 class InstalledAppsCollector(SnapshotCollector):

--- a/src/avai/host_monitor/models.py
+++ b/src/avai/host_monitor/models.py
@@ -367,6 +367,7 @@ class FileScanRow(_RowBase):
     rule: Mapped[Optional[str]]
     namespace: Mapped[Optional[str]]
     tags_json: Mapped[Optional[str]]
+    meta_json: Mapped[Optional[str]]
     size: Mapped[Optional[int]]
     mtime: Mapped[Optional[float]]
     scan_source: Mapped[Optional[str]]

--- a/src/avai/migrations/versions/0006_file_scan_meta.py
+++ b/src/avai/migrations/versions/0006_file_scan_meta.py
@@ -1,0 +1,40 @@
+"""file_scan.meta_json — retain matched-rule meta (author/reference/…)
+
+Adds the meta_json column written by FileScanCollector. It carries each
+matched YARA rule's meta dict, which is needed to satisfy the
+signature-base DRL attribution obligation (match output must retain author
+identification) and gives the judge/dashboard rule context.
+
+Guarded with a PRAGMA check: a fresh DB already has the column from
+create_all (the model carries it), so ALTER would raise "duplicate column"
+there — only an incrementally-migrated DB needs the ADD COLUMN.
+
+Revision ID: 0006_file_scan_meta
+Revises: 0005_file_scan
+Create Date: 2026-06-16
+"""
+
+from alembic import op
+
+revision = "0006_file_scan_meta"
+down_revision = "0005_file_scan"
+branch_labels = None
+depends_on = None
+
+
+def _has_column(bind, table: str, column: str) -> bool:
+    rows = bind.exec_driver_sql(f"PRAGMA table_info({table})").fetchall()
+    return any(r[1] == column for r in rows)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if not _has_column(bind, "file_scan", "meta_json"):
+        op.execute("ALTER TABLE file_scan ADD COLUMN meta_json VARCHAR")
+
+
+def downgrade() -> None:
+    # SQLite gained DROP COLUMN in 3.35; guard so it's a no-op when absent.
+    bind = op.get_bind()
+    if _has_column(bind, "file_scan", "meta_json"):
+        op.execute("ALTER TABLE file_scan DROP COLUMN meta_json")

--- a/src/avai/rules/NOTICE
+++ b/src/avai/rules/NOTICE
@@ -10,39 +10,56 @@ Contents shipped in the repo
                     Guarantees scanning is functional out of the box.
 - hash_denylist.txt Empty deny-list template (avai-authored, MIT).
 
-Curated rule pack (vendor/) — opt-in, never shipped
----------------------------------------------------
-A curated pack (YARA-Forge "core") is fetched into ./vendor/ by
-`scripts/update_rules.py`, which pins an exact upstream release for
-reproducibility. It is intentionally NOT committed to this repo and NOT
-included in the published wheel/sdist (see the exclude in pyproject.toml):
-users fetch it post-install for their own environment.
+Opt-in rule packs (vendor/<source>/) — never shipped
+----------------------------------------------------
+`scripts/update_rules.py` fetches a pinned pack into ./vendor/<source>/.
+Packs are NOT committed and NOT in the published wheel/sdist (gitignored +
+excluded in pyproject.toml); users fetch them post-install per environment.
 
-REQUIRES a crypto-enabled yara
-------------------------------
-~200 rules in the pack use pe.imphash() and the hash.* module, which need
-a yara built with OpenSSL. The PyPI `yara-python` wheel is built WITHOUT
-crypto, so on a stock `pip install` those functions don't compile — and
-because the pack is one consolidated file, that makes the whole pack
-fail to load (the collector logs a warning and falls back to the bundled
-EICAR rule). To use the pack, install a crypto-enabled yara (e.g. build
-`yara-python` against a libyara with OpenSSL, or use a distro/homebrew
-yara with the bindings) before running update_rules.py.
+    python scripts/update_rules.py                      # signature-base (default)
+    python scripts/update_rules.py --source yara-forge  # YARA-Forge core
+    python scripts/update_rules.py --ref <sha-or-tag>   # bump the pin
 
-LICENSING — read before committing the pack
---------------------------------------------
-avai itself is MIT. YARA-Forge aggregates community rules under MIXED
-licenses, some copyleft. Those rules are NOT relicensed under MIT: when
-the pack is vendored, its upstream LICENSE / attribution files are kept
-alongside it under ./vendor/, and this NOTICE points at them. Shipping the
-pack is a deliberate licensing decision that needs a human sign-off — do
-not commit ./vendor/ until that review is done.
+1) signature-base (Neo23x0/signature-base) — RECOMMENDED
+--------------------------------------------------------
+Florian Roth's signature-base. Hundreds of individual *.yar files, so the
+collector's per-file compile degrades gracefully: on the measured snapshot
+~651 of 746 files (≈87%, ~5,250 rules) compile on the stock PyPI yara; the
+~95 that use pe.imphash()/hash.* are skipped individually (they need a
+crypto-enabled yara — see below) rather than taking the whole pack down.
 
-Refreshing the pack
--------------------
-    python scripts/update_rules.py            # fetch the pinned release
-    python scripts/update_rules.py --version X.Y.Z   # bump the pin
+Its rules expect scanner EXTERNAL VARIABLES (filename, filepath, extension,
+filetype, md5, owner) — without them yara raises "undefined identifier".
+avai supplies them (empty placeholders at compile, real per-file values at
+match), mirroring LOKI/THOR, so the rules compile and match.
 
-Users can always drop their own *.yar / *.yara files in this directory
-(or set AVAI_YARA_RULES_DIR) — uncompilable files are skipped with a
-warning, never silently, and never disable the rest of the ruleset.
+LICENSE: Detection Rule License (DRL) 1.1. It PERMITS commercial use and
+bundling in an MIT project, BUT requires: preserve author identification,
+provide a link to the source, include the license notice, and — when rules
+are applied to data — retain author info in the match output. avai keeps
+the upstream LICENSE under ./vendor/signature-base/ and stores each matched
+rule's meta (author/reference) on the finding (file_scan.meta_json) to
+honour the attribution-on-match obligation. The pack stays opt-in/unshipped
+regardless.
+
+2) YARA-Forge core (YARAHQ/yara-forge)
+--------------------------------------
+One consolidated *.yar, MIXED licenses (some copyleft) — needs a human
+sign-off before being committed/shipped anywhere. Because it is a single
+file, one unsupported construct (pe.imphash on a crypto-less yara) makes
+the WHOLE pack fail to load. Prefer signature-base unless you specifically
+need YARA-Forge's aggregation.
+
+Crypto-enabled yara (for imphash / hash.* rules)
+------------------------------------------------
+The PyPI `yara-python` wheel is built WITHOUT OpenSSL, so pe.imphash() and
+the hash.* module read as "invalid field name" and those rule files are
+skipped (the collector logs an actionable hint). To load them, install a
+yara built with OpenSSL (e.g. build yara-python against a libyara with
+crypto, or use a distro/homebrew yara with the bindings).
+
+Custom rules
+------------
+Drop your own *.yar / *.yara in this directory (or point AVAI_YARA_RULES_DIR
+elsewhere) — uncompilable files are skipped with a warning, never silently,
+and never disable the rest of the ruleset.

--- a/tests/test_file_scan.py
+++ b/tests/test_file_scan.py
@@ -10,6 +10,7 @@ broken shipped rule disabling scanning.
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 
@@ -24,6 +25,7 @@ from avai.host_monitor.collectors import (
     FileScanCollector,
     _compile_yara_rules,
     _crypto_hint,
+    _file_type,
 )
 
 _MARKER = "AVAITESTMATCH"
@@ -189,6 +191,98 @@ class TestFileScanCollector:
     def test_bundled_eicar_rules_compile(self):
         # Guards against a broken shipped rule silently disabling scanning.
         assert _compile_yara_rules(C.YARA_RULES_DIR) is not None
+
+
+class TestYaraExternals:
+    """signature-base rules reference scanner externals; the collector must
+    define them at compile and supply real per-file values at match."""
+
+    def _rules(self, tmp_path: Path, body: str) -> Path:
+        d = tmp_path / "rules"
+        d.mkdir()
+        (d / "ext.yar").write_text(body)
+        return d
+
+    def test_filename_external_compiles_and_matches(self, tmp_path):
+        # Without externals support this rule fails to compile
+        # ("undefined identifier"); it must compile AND gate on the name.
+        rules = self._rules(tmp_path, 'rule t { condition: filename == "evil.bin" }')
+        bindir = tmp_path / "bin"
+        bindir.mkdir()
+        (bindir / "evil.bin").write_text("anything")
+        (bindir / "innocent.txt").write_text("anything")
+        rows = list(
+            FileScanCollector(fs=_FakeFs(bin_dirs=[bindir]), rules_dir=rules).collect()
+        )
+        assert [Path(r["path"]).name for r in rows] == ["evil.bin"]
+
+    def test_filetype_external_gates_on_magic(self, tmp_path):
+        rules = self._rules(tmp_path, 'rule t { condition: filetype == "EXE" }')
+        bindir = tmp_path / "bin"
+        bindir.mkdir()
+        (bindir / "real.exe").write_bytes(b"MZ\x90\x00binary")
+        (bindir / "notes.txt").write_text("plain text, not an exe")
+        rows = list(
+            FileScanCollector(fs=_FakeFs(bin_dirs=[bindir]), rules_dir=rules).collect()
+        )
+        assert [Path(r["path"]).name for r in rows] == ["real.exe"]
+
+    def test_meta_retained_on_finding(self, tmp_path):
+        rules = self._rules(
+            tmp_path,
+            'rule t { meta: author = "Jane Doe" reference = "https://x" '
+            f'strings: $a = "{_MARKER}" condition: $a }}',
+        )
+        bindir = tmp_path / "bin"
+        bindir.mkdir()
+        (bindir / "evil.bin").write_text(_MARKER)
+        rows = list(
+            FileScanCollector(fs=_FakeFs(bin_dirs=[bindir]), rules_dir=rules).collect()
+        )
+        assert len(rows) == 1
+        meta = json.loads(rows[0]["meta_json"])
+        assert meta["author"] == "Jane Doe"
+        assert meta["reference"] == "https://x"
+
+    def test_crypto_rule_file_does_not_disable_others(self, tmp_path):
+        # A hash.* rule file (needs crypto yara) sits beside a plain rule.
+        # The plain rule must still compile and match regardless of whether
+        # this yara build has crypto (skip) or not (compiles, just no match).
+        d = tmp_path / "rules"
+        d.mkdir()
+        (d / "good.yar").write_text(
+            f'rule good {{ strings: $a = "{_MARKER}" condition: $a }}'
+        )
+        (d / "crypto.yar").write_text(
+            'import "hash"\nrule c { condition: hash.md5(0, filesize) == "x" }'
+        )
+        bindir = tmp_path / "bin"
+        bindir.mkdir()
+        (bindir / "evil.bin").write_text(_MARKER)
+        rows = list(
+            FileScanCollector(fs=_FakeFs(bin_dirs=[bindir]), rules_dir=d).collect()
+        )
+        assert any(r["rule"] == "good" for r in rows)
+
+
+class TestFileType:
+    def test_detects_known_magics(self, tmp_path):
+        cases = {
+            b"MZ\x90\x00": "EXE",
+            b"\x7fELF\x02\x01": "ELF",
+            b"\xcf\xfa\xed\xfe": "MACH-O",
+            b"MDMP\x93\xa7": "MDMP",
+        }
+        for header, expected in cases.items():
+            f = tmp_path / f"f_{expected}"
+            f.write_bytes(header + b"\x00\x00\x00\x00")
+            assert _file_type(f) == expected
+
+    def test_unknown_and_unreadable_return_empty(self, tmp_path):
+        text = tmp_path / "plain.txt"
+        text.write_text("just text")
+        assert _file_type(text) == ""
+        assert _file_type(tmp_path / "does-not-exist") == ""
 
 
 class TestCryptoHint:

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -53,7 +53,7 @@ def test_sink_setup_applies_migrations(tmp_path):
     Sink(create_engine(f"sqlite:///{db}")).setup()
     assert set(_IDX) <= _indexes(db)
     assert "control_state" in _tables(db)
-    assert _version(db) == "0005_file_scan"
+    assert _version(db) == "0006_file_scan_meta"
 
 
 def test_upgrade_stamps_preexisting_create_all_db(tmp_path):
@@ -74,7 +74,7 @@ def test_upgrade_stamps_preexisting_create_all_db(tmp_path):
 
     upgrade_to_head(f"sqlite:///{db}")  # stamps baseline then adds indexes
     assert set(_IDX) <= _indexes(db)
-    assert _version(db) == "0005_file_scan"
+    assert _version(db) == "0006_file_scan_meta"
 
 
 def test_downgrade_then_upgrade_roundtrip(tmp_path):
@@ -107,7 +107,7 @@ def test_control_state_migration_roundtrip(tmp_path):
 
     command.upgrade(_config(f"sqlite:///{db}"), "head")
     assert "control_state" in _tables(db)
-    assert _version(db) == "0005_file_scan"
+    assert _version(db) == "0006_file_scan_meta"
 
     command.downgrade(_config(f"sqlite:///{db}"), "0002_perf_indexes")
     assert "control_state" not in _tables(db)


### PR DESCRIPTION
Adds Florian Roth's **signature-base** as the recommended opt-in YARA source and makes its rules actually compile + match.

## The problem
signature-base rules require scanner **external variables** (`filename`/`filepath`/`extension`/`filetype`/`md5`/`owner`) — without them yara raises `undefined identifier`. They're also distributed as **hundreds of individual files**, which (unlike YARA-Forge's single consolidated file) lets the per-file compile degrade gracefully on the crypto-less PyPI wheel.

## What changed
- **`update_rules.py`** — multi-source via `--source`; `signature-base` (tarball at a pinned commit → `vendor/signature-base/`) + existing `yara-forge`. Both opt-in (gitignored + build-excluded).
- **`collectors.py`** — define the LOKI/THOR externals at compile, supply real per-file values at match (`filetype` via magic bytes; `md5` left empty — measured zero rules use it). Keep per-file namespaces (measured: all 5,257 survivor rules compile, no cross-file deps). Retain matched-rule `meta` on the finding for DRL attribution.
- **`models.py` + migration 0006** — `file_scan.meta_json` (PRAGMA-guarded ALTER).
- **NOTICE** — signature-base, DRL 1.1 (permits MIT bundling w/ attribution), externals, crypto-yara note.

## Verified (pinned snapshot, stock PyPI wheel)
- **651/746 files (~5,250 rules)** compile; 95 crypto files skip individually.
- A real signature-base rule (`SUSP_Just_EICAR`, Florian Roth) matches EICAR **with author retained**.
- ~8 ms/file, ~11s for the bounded target set; compile-once 3.4s.
- 740 tests pass; ruff clean.