### PR TITLE
feat(dashboard): File Scan panel — YARA ruleset summary + matches

### DIFF
--- a/src/avai/cli.py
+++ b/src/avai/cli.py
@@ -41,7 +41,7 @@ def _cmd_rules(rules_dir: Path, do_list: bool) -> int:
     user-facing answer to 'which rules are available?'. Read-only; no DB."""
     from .host_monitor.collectors import _compile_yara_rules
 
-    rules = _compile_yara_rules(rules_dir)
+    rules, _stats = _compile_yara_rules(rules_dir)
     if rules is None:
         print(f"avai: no compilable YARA rules under {rules_dir}", file=sys.stderr)
         return 1

--- a/src/avai/dashboard/app.py
+++ b/src/avai/dashboard/app.py
@@ -38,6 +38,7 @@ from .queries import (
     cost_since,
     disk_usage,
     dns_queries,
+    file_scan,
     findings,
     host_resources,
     judged_since,
@@ -655,6 +656,20 @@ def fragment_findings():
             collector_options=collector_options(s),
             category_options=category_options(s),
             per_page_options=PER_PAGE_OPTIONS,
+        )
+
+
+@app.route("/fragments/file-scan")
+def fragment_file_scan():
+    verdict = request.args.get("verdict", "")
+    q = request.args.get("q", "")
+    with _session() as s:
+        latest = latest_run(s)
+        return render_template(
+            "partials/_file_scan.html",
+            data=(
+                file_scan(s, latest.run_id, verdict=verdict, q=q) if latest else None
+            ),
         )
 
 

--- a/src/avai/dashboard/queries.py
+++ b/src/avai/dashboard/queries.py
@@ -68,6 +68,7 @@ from avai.host_monitor import (
     SystemIntegrityRow,
     UsbDeviceRow,
     WifiStateRow,
+    YaraStatusRow,
 )
 
 COLLECTOR_MODELS = {
@@ -1632,6 +1633,73 @@ def network_exposure(
         "verdict": verdict,
         "q": q,
         "any": bool(proxies or shares or sessions or promisc),
+    }
+
+
+def yara_status(session: Session) -> "dict | None":
+    """The file scanner's compiled-ruleset summary (single row, written by
+    the monitor). ``None`` when the scanner has never compiled — e.g. a DB
+    from before the monitor ran the file_scan collector."""
+    if YaraStatusRow.__tablename__ not in _existing_tables(session):
+        return None
+    row = session.get(YaraStatusRow, 1)
+    if row is None:
+        return None
+    by_category = json.loads(row.by_category_json or "{}")
+    return {
+        "compiled_at": row.compiled_at,
+        "rules_loaded": row.rules_loaded,
+        "files_loaded": row.files_loaded,
+        "files_skipped": row.files_skipped,
+        "rules_dir": row.rules_dir,
+        "sources": json.loads(row.sources_json or "{}"),
+        "skip_reasons": json.loads(row.skip_reasons_json or "{}"),
+        # Top categories descending — the long tail isn't worth the pixels.
+        "top_categories": sorted(
+            by_category.items(), key=lambda kv: kv[1], reverse=True
+        )[:12],
+        "category_count": len(by_category),
+    }
+
+
+def file_scan(
+    session: Session,
+    run_id: str,
+    verdict: str = "",
+    q: str = "",
+    limit: int = 500,
+) -> dict:
+    """The File Scan panel: the compiled-ruleset summary plus this run's
+    YARA matches (file_scan rows annotated with their LLM verdict), each
+    carrying the matched rule's author parsed from its meta for attribution.
+    """
+    matches = _collector_rows_with_verdict(
+        session,
+        run_id,
+        FileScanRow,
+        "file_scan",
+        ("rule", "path", "sha256", "scan_source", "tags_json", "meta_json"),
+        limit,
+    )
+    for m in matches:
+        meta = json.loads(m.get("meta_json") or "{}")
+        m["author"] = meta.get("author") or ""
+    if verdict:
+        matches = [m for m in matches if m.get("verdict") == verdict]
+    if q:
+        ql = q.lower()
+        matches = [
+            m
+            for m in matches
+            if any(
+                ql in str(m.get(f) or "").lower() for f in ("rule", "path", "author")
+            )
+        ]
+    return {
+        "status": yara_status(session),
+        "matches": matches,
+        "verdict": verdict,
+        "q": q,
     }
 
 

--- a/src/avai/host_monitor/__init__.py
+++ b/src/avai/host_monitor/__init__.py
@@ -139,6 +139,7 @@ from .models import (
     SystemIntegrityRow,
     UsbDeviceRow,
     WifiStateRow,
+    YaraStatusRow,
     _RowBase,
 )
 from .narrator import IncidentNarrator, build_narrator
@@ -306,6 +307,7 @@ __all__ = [
     "WATCHED_FILES_LINUX",
     "WifiCollector",
     "WifiStateRow",
+    "YaraStatusRow",
     "_CORRELATED_COLLECTOR",
     "_PKG_DIR",
     "_RowBase",

--- a/src/avai/host_monitor/collectors.py
+++ b/src/avai/host_monitor/collectors.py
@@ -1328,10 +1328,22 @@ def _file_type(path: Path) -> str:
     return ""
 
 
+def _rule_source(path: Path, rules_dir: Path) -> str:
+    """Label a rule file by where it came from: top-level files are
+    ``bundled``; a vendored pack file (``vendor/<name>/…``) is ``<name>``."""
+    try:
+        parts = path.relative_to(rules_dir).parts
+    except ValueError:
+        return "other"
+    return "bundled" if len(parts) == 1 else parts[-2]
+
+
 def _compile_yara_rules(rules_dir: Path):
     """Compile every ``*.yar`` / ``*.yara`` under ``rules_dir`` into one
-    :class:`yara.Rules`. Returns ``None`` when the directory is absent or
-    holds no compilable rules.
+    :class:`yara.Rules`. Returns ``(rules, stats)`` — ``rules`` is ``None``
+    when the directory is absent or holds no compilable rules; ``stats`` is
+    always a summary dict (counts, sources, skip reasons, per-category) for
+    the dashboard's File Scan panel.
 
     Each file is validated independently first and uncompilable ones are
     skipped with a warning, so a single malformed rule in a fetched pack
@@ -1341,17 +1353,29 @@ def _compile_yara_rules(rules_dir: Path):
     files. ``_YARA_EXTERNALS`` is supplied so rules referencing scanner
     externals (filename/filepath/extension/filetype/…) compile.
     """
+    stats = {
+        "rules_loaded": 0,
+        "files_loaded": 0,
+        "files_skipped": 0,
+        "skip_reasons": {},
+        "by_category": {},
+        "sources": {},
+        "rules_dir": str(rules_dir),
+    }
     if not rules_dir.is_dir():
-        return None
+        return None, stats
     filepaths: dict[str, str] = {}
-    skipped = 0
+    skip_reasons: dict[str, int] = {}
+    by_category: dict[str, int] = {}
+    sources: dict[str, int] = {}
     for path in sorted(rules_dir.rglob("*")):
         if path.suffix.lower() not in (".yar", ".yara") or not path.is_file():
             continue
         try:
             yara.compile(filepath=str(path), externals=_YARA_EXTERNALS)
         except yara.Error as exc:
-            skipped += 1
+            reason = "needs crypto-enabled yara" if _crypto_hint(exc) else "other"
+            skip_reasons[reason] = skip_reasons.get(reason, 0) + 1
             constants.LOG.warning(
                 "yara: skipping uncompilable rules %s: %s%s",
                 path,
@@ -1366,23 +1390,35 @@ def _compile_yara_rules(rules_dir: Path):
             unique = f"{namespace}_{suffix}"
             suffix += 1
         filepaths[unique] = str(path)
+        category = path.stem.split("_", 1)[0]
+        by_category[category] = by_category.get(category, 0) + 1
+        source = _rule_source(path, rules_dir)
+        sources[source] = sources.get(source, 0) + 1
+    stats.update(
+        files_loaded=len(filepaths),
+        files_skipped=sum(skip_reasons.values()),
+        skip_reasons=skip_reasons,
+        by_category=by_category,
+        sources=sources,
+    )
     if not filepaths:
-        return None
+        return None, stats
     try:
         compiled = yara.compile(filepaths=filepaths, externals=_YARA_EXTERNALS)
     except yara.Error as exc:
         constants.LOG.warning("yara: combined compile failed: %s", exc)
-        return None
+        return None, stats
+    stats["rules_loaded"] = sum(1 for _ in compiled)
     # One-line visibility into what the scanner actually loaded — the only
     # place rule counts surface, since there's no per-match log.
     constants.LOG.info(
         "yara: loaded %d rules from %d files (skipped %d) under %s",
-        sum(1 for _ in compiled),
-        len(filepaths),
-        skipped,
+        stats["rules_loaded"],
+        stats["files_loaded"],
+        stats["files_skipped"],
         rules_dir,
     )
-    return compiled
+    return compiled, stats
 
 
 class FileScanCollector(SnapshotCollector):
@@ -1420,10 +1456,13 @@ class FileScanCollector(SnapshotCollector):
         self._clock = clock or Clock()
         self._rules = None  # compiled once, lazily
         self._compiled = False
+        # Ruleset summary from the last compile — read by the Runner to
+        # persist yara_status for the dashboard. None until first collect().
+        self.compile_stats: Optional[dict] = None
 
     def _ruleset(self):
         if not self._compiled:
-            self._rules = _compile_yara_rules(self._rules_dir)
+            self._rules, self.compile_stats = _compile_yara_rules(self._rules_dir)
             self._compiled = True
         return self._rules
 

--- a/src/avai/host_monitor/models.py
+++ b/src/avai/host_monitor/models.py
@@ -360,6 +360,24 @@ class FileIntegrityRow(_RowBase):
     exists_flag: Mapped[Optional[int]]
 
 
+class YaraStatusRow(Base):
+    """Single-row (id=1) snapshot of the file scanner's compiled ruleset,
+    written by the monitor each cycle so the read-only dashboard can show
+    what's loaded (the compiled rules live only in the monitor's memory and
+    are never otherwise persisted)."""
+
+    __tablename__ = "yara_status"
+    id: Mapped[int] = mapped_column(primary_key=True, default=1)
+    compiled_at: Mapped[Optional[str]]
+    rules_loaded: Mapped[Optional[int]]
+    files_loaded: Mapped[Optional[int]]
+    files_skipped: Mapped[Optional[int]]
+    rules_dir: Mapped[Optional[str]]
+    sources_json: Mapped[Optional[str]]  # {"bundled": 1, "signature-base": 651}
+    skip_reasons_json: Mapped[Optional[str]]  # {"crypto": 95}
+    by_category_json: Mapped[Optional[str]]  # {"apt": 315, "gen": 170, ...}
+
+
 class FileScanRow(_RowBase):
     __tablename__ = "file_scan"
     path: Mapped[str] = mapped_column(index=True)

--- a/src/avai/host_monitor/runner.py
+++ b/src/avai/host_monitor/runner.py
@@ -190,6 +190,8 @@ class Runner:
                 self._generate_narrative(run_id, started)
             # Deterministic posture score — always computed (no LLM needed).
             self._generate_risk_score(run_id, started)
+            # Persist the file scanner's ruleset summary for the dashboard.
+            self._write_yara_status()
         self.sink.end_run(ok, failed)
 
         # Rotation: keep the DB under the configured size cap by pruning
@@ -550,6 +552,25 @@ class Runner:
             LOG.info("risk score=%d grade=%s", result["score"], result["grade"])
         except Exception as exc:
             LOG.warning("risk: write failed: %s", exc)
+
+    def _write_yara_status(self) -> None:
+        """Persist the file scanner's last compile summary (rules loaded /
+        skipped / by source / category) so the read-only dashboard can show
+        the ruleset. Best-effort — never raises."""
+        stats = next(
+            (
+                c.compile_stats
+                for c in self.snapshot_collectors
+                if getattr(c, "compile_stats", None) is not None
+            ),
+            None,
+        )
+        if stats is None:
+            return
+        try:
+            self.sink.write_yara_status(stats)
+        except Exception as exc:  # noqa: BLE001
+            LOG.warning("yara_status: write failed: %s", exc)
 
     @staticmethod
     def _risk_explanation(result: dict, prev) -> str:

--- a/src/avai/host_monitor/sink.py
+++ b/src/avai/host_monitor/sink.py
@@ -43,6 +43,7 @@ from .models import (
     RiskScoreRow,
     StreamingSession,
     SystemIntegrityRow,
+    YaraStatusRow,
     _RowBase,
 )
 from .runtime import Clock
@@ -533,6 +534,25 @@ class Sink:
     def write_risk_score(self, row: dict) -> None:
         with Session(self.engine) as session:
             session.add(RiskScoreRow(**row))
+            session.commit()
+
+    def write_yara_status(self, stats: dict) -> None:
+        """Upsert the single-row file-scanner ruleset summary (id=1) so the
+        read-only dashboard can show what's loaded."""
+        with Session(self.engine) as session:
+            session.merge(
+                YaraStatusRow(
+                    id=1,
+                    compiled_at=Clock().now_iso(),
+                    rules_loaded=stats.get("rules_loaded"),
+                    files_loaded=stats.get("files_loaded"),
+                    files_skipped=stats.get("files_skipped"),
+                    rules_dir=stats.get("rules_dir"),
+                    sources_json=json.dumps(stats.get("sources") or {}),
+                    skip_reasons_json=json.dumps(stats.get("skip_reasons") or {}),
+                    by_category_json=json.dumps(stats.get("by_category") or {}),
+                )
+            )
             session.commit()
 
     def database_size_bytes(self) -> int:

--- a/src/avai/migrations/versions/0007_yara_status.py
+++ b/src/avai/migrations/versions/0007_yara_status.py
@@ -1,0 +1,42 @@
+"""yara_status — single-row snapshot of the compiled file-scan ruleset
+
+The dashboard is read-only and can't see the monitor's in-memory YARA
+ruleset, so the monitor persists a summary here (counts, sources, skip
+reasons, per-category breakdown) for the File Scan panel to render.
+
+CREATE TABLE IF NOT EXISTS so it's a no-op on a fresh create_all DB and a
+real create on an incrementally-migrated one.
+
+Revision ID: 0007_yara_status
+Revises: 0006_file_scan_meta
+Create Date: 2026-06-17
+"""
+
+from alembic import op
+
+revision = "0007_yara_status"
+down_revision = "0006_file_scan_meta"
+branch_labels = None
+depends_on = None
+
+_YARA_STATUS = """
+CREATE TABLE IF NOT EXISTS yara_status (
+    id INTEGER NOT NULL PRIMARY KEY,
+    compiled_at VARCHAR,
+    rules_loaded INTEGER,
+    files_loaded INTEGER,
+    files_skipped INTEGER,
+    rules_dir VARCHAR,
+    sources_json VARCHAR,
+    skip_reasons_json VARCHAR,
+    by_category_json VARCHAR
+)
+"""
+
+
+def upgrade() -> None:
+    op.execute(_YARA_STATUS)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS yara_status")

--- a/src/avai/templates/dashboard.html
+++ b/src/avai/templates/dashboard.html
@@ -301,6 +301,12 @@
              hx-trigger="load, every 60s"
              hx-swap="innerHTML"></section>
 
+    {# ---------- file scan (YARA ruleset + matches) ---------- #}
+    <section id="file-scan-panel"
+             hx-get="/fragments/file-scan"
+             hx-trigger="load, every 60s"
+             hx-swap="innerHTML"></section>
+
     {# ---------- auth events (unified log stream) ---------- #}
     <section id="auth-events"
              hx-get="/fragments/auth-events"

--- a/src/avai/templates/partials/_file_scan.html
+++ b/src/avai/templates/partials/_file_scan.html
@@ -1,0 +1,138 @@
+{% from "partials/_macros.html" import card_header, verdict_pill %}
+
+{# File scan — the compiled YARA ruleset summary (what's loaded, from which
+   sources, how many skipped) plus this run's matches. The ruleset lives only
+   in the monitor process, so the monitor persists this summary for the
+   read-only dashboard to render. #}
+
+<div id="file-scan" class="bg-slate-900 border border-slate-800 rounded-lg p-5">
+  {{ card_header("File scan — YARA ruleset & matches") }}
+
+  {# ===== Ruleset summary ===== #}
+  {% set st = data.status if data else none %}
+  {% if st and st.rules_loaded %}
+    <div class="mb-5">
+      <div class="flex flex-wrap items-baseline gap-x-5 gap-y-1">
+        <div>
+          <span class="text-2xl font-semibold text-slate-100">{{ "{:,}".format(st.rules_loaded) }}</span>
+          <span class="text-slate-500 text-xs ml-1">rules loaded</span>
+        </div>
+        <div class="text-xs text-slate-400">
+          {{ st.files_loaded }} files
+          {% if st.files_skipped %}
+            · <span class="text-amber-300">{{ st.files_skipped }} skipped</span>
+            {% for reason, n in st.skip_reasons.items() %}
+              <span class="text-slate-500">({{ n }} {{ reason }})</span>
+            {% endfor %}
+          {% endif %}
+        </div>
+        {% if st.compiled_at %}
+          <div class="text-[10px] uppercase tracking-wider text-slate-600">compiled {{ st.compiled_at }}</div>
+        {% endif %}
+      </div>
+
+      {% if st.sources %}
+        <div class="mt-2 flex flex-wrap gap-1.5">
+          {% for name, n in st.sources.items() %}
+            <span class="bg-slate-800 border border-slate-700 rounded px-2 py-0.5 text-[11px] text-slate-300">
+              {{ name }} <span class="text-slate-500">{{ "{:,}".format(n) }}</span>
+            </span>
+          {% endfor %}
+        </div>
+      {% endif %}
+
+      {% if st.top_categories %}
+        <div class="mt-2">
+          <div class="text-[10px] uppercase tracking-wider text-slate-600 mb-1">
+            top categories{% if st.category_count > st.top_categories|length %} (of {{ st.category_count }}){% endif %}
+          </div>
+          <div class="flex flex-wrap gap-1.5">
+            {% for name, n in st.top_categories %}
+              <span class="text-[11px] text-slate-400 font-mono">{{ name }}<span class="text-slate-600">·{{ n }}</span></span>
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
+    </div>
+  {% elif st %}
+    <div class="mb-5 text-slate-500 text-xs italic">
+      no YARA rules loaded — drop rules under the rules dir, or fetch a pack
+      with <span class="font-mono">scripts/update_rules.py</span>.
+    </div>
+  {% else %}
+    <div class="mb-5 text-slate-500 text-xs italic">
+      the file scanner hasn't compiled a ruleset yet — wait for a collection
+      cycle to complete.
+    </div>
+  {% endif %}
+
+  {# ===== Matches ===== #}
+  {% if data %}
+  <form id="file-scan-filters"
+        class="mb-3 flex flex-wrap items-center gap-2 text-xs"
+        onsubmit="return false;">
+    <input type="search"
+           name="q"
+           value="{{ data.q }}"
+           placeholder="search rule / path / author"
+           aria-label="search YARA matches by rule, path or author"
+           autocomplete="off"
+           class="bg-slate-800 border border-slate-700 rounded px-2 py-1 w-56 focus:outline-none focus:border-slate-500 placeholder:text-slate-600"
+           hx-get="/fragments/file-scan"
+           hx-target="#file-scan"
+           hx-include="#file-scan-filters"
+           hx-trigger="keyup changed delay:300ms, search">
+
+    <select name="verdict"
+            aria-label="filter YARA matches by verdict"
+            class="bg-slate-800 border border-slate-700 rounded px-2 py-1 focus:outline-none focus:border-slate-500"
+            hx-get="/fragments/file-scan"
+            hx-target="#file-scan"
+            hx-include="#file-scan-filters"
+            hx-trigger="change">
+      <option value=""           {% if data.verdict == "" %}selected{% endif %}>all non-benign</option>
+      <option value="malicious"  {% if data.verdict == "malicious" %}selected{% endif %}>malicious</option>
+      <option value="suspicious" {% if data.verdict == "suspicious" %}selected{% endif %}>suspicious</option>
+      <option value="unknown"    {% if data.verdict == "unknown" %}selected{% endif %}>unknown</option>
+      <option value="benign"     {% if data.verdict == "benign" %}selected{% endif %}>benign (all)</option>
+    </select>
+  </form>
+  {% endif %}
+
+  {% if data and data.matches %}
+    <div class="overflow-x-auto">
+    <table class="w-full text-xs">
+      <thead>
+        <tr class="text-slate-500 uppercase tracking-wider text-[10px]">
+          <th class="text-left font-semibold pb-2">verdict</th>
+          <th class="text-left font-semibold pb-2">rule</th>
+          <th class="text-left font-semibold pb-2">path</th>
+          <th class="text-left font-semibold pb-2">author</th>
+          <th class="text-left font-semibold pb-2">source</th>
+          <th class="text-left font-semibold pb-2 w-1/4">why</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-slate-800/80">
+        {% for m in data.matches %}
+          <tr class="hover:bg-slate-800/40 transition-colors">
+            <td class="py-2">
+              {% if m.verdict %}{{ verdict_pill(m.verdict, m.confidence) }}
+              {% else %}<span class="text-slate-600 text-[10px] uppercase tracking-wider">—</span>{% endif %}
+            </td>
+            <td class="py-2 font-mono text-slate-200 break-all">{{ m.rule or "—" }}</td>
+            <td class="py-2 font-mono text-slate-300 break-all">{{ m.path or "—" }}</td>
+            <td class="py-2 text-slate-400 break-all">{{ m.author or "—" }}</td>
+            <td class="py-2 text-slate-500">{{ m.scan_source or "—" }}</td>
+            <td class="py-2 text-slate-400 line-clamp-2">{{ m.reasoning }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    </div>
+  {% elif data %}
+    <div class="text-slate-500 text-xs italic">
+      no YARA matches{% if data.q or data.verdict %} for the current filters{% endif %} —
+      a clean host with no rule hits looks exactly like this.
+    </div>
+  {% endif %}
+</div>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -341,6 +341,77 @@ class TestDashboardEndpoints:
         assert "/usr/local/bin/dropper" in body  # the scanned path
         assert "malicious" in body
 
+    def test_file_scan_panel_renders_ruleset_summary_and_matches(self, client):
+        # The File Scan panel shows the persisted ruleset summary (counts,
+        # sources, categories) AND this run's matches with rule/path/author.
+        from avai.host_monitor import CollectionRun, FileScanRow, Judgement, Sink
+
+        Sink(_engine_rw(app.config["DB_PATH"])).write_yara_status(
+            {
+                "rules_loaded": 5292,
+                "files_loaded": 656,
+                "files_skipped": 95,
+                "rules_dir": "/x",
+                "sources": {"signature-base": 655, "bundled": 1},
+                "skip_reasons": {"needs crypto-enabled yara": 95},
+                "by_category": {"apt": 260, "gen": 156},
+            }
+        )
+        with Session(_engine_rw(app.config["DB_PATH"])) as s:
+            s.add(
+                CollectionRun(
+                    run_id="run1",
+                    started_at="2026-05-30T12:00:00Z",
+                    finished_at="2026-05-30T12:01:00Z",
+                    hostname="h",
+                    lookback_min=5,
+                )
+            )
+            s.add(
+                FileScanRow(
+                    run_id="run1",
+                    collected_at="2026-05-30T12:00:00Z",
+                    content_hash="fs1",
+                    path="/usr/bin/evil",
+                    sha256="a" * 64,
+                    rule="SUSP_Just_EICAR",
+                    namespace="thor",
+                    tags_json='["FILE"]',
+                    meta_json='{"author": "Florian Roth"}',
+                    scan_source="bin_dirs",
+                )
+            )
+            s.add(
+                Judgement(
+                    content_hash="fs1",
+                    collector="file_scan",
+                    verdict="malicious",
+                    category="execution",
+                    confidence=0.9,
+                    reasoning="matched a known dropper pattern",
+                    remediation="quarantine",
+                    model="m",
+                    created_at="2026-05-30T12:00:30Z",
+                    last_seen_at="2026-05-30T12:00:00Z",
+                )
+            )
+            s.commit()
+
+        body = client.get("/fragments/file-scan").data.decode()
+        # ruleset summary
+        assert "5,292" in body and "rules loaded" in body
+        assert "signature-base" in body
+        assert "apt" in body  # category breakdown
+        # the match
+        assert "SUSP_Just_EICAR" in body
+        assert "/usr/bin/evil" in body
+        assert "Florian Roth" in body  # author attribution
+        assert "malicious" in body
+
+    def test_file_scan_panel_empty_db_shows_not_compiled(self, client):
+        body = client.get("/fragments/file-scan").data.decode()
+        assert "hasn't compiled" in body  # graceful empty state
+
     def test_network_panel_is_an_accessible_tablist(self, client):
         # WAI-ARIA tabs pattern: the tab strip must be a tablist of tabs that
         # control the shared panel, with exactly one tab pre-selected.

--- a/tests/test_file_scan.py
+++ b/tests/test_file_scan.py
@@ -190,7 +190,10 @@ class TestFileScanCollector:
 
     def test_bundled_eicar_rules_compile(self):
         # Guards against a broken shipped rule silently disabling scanning.
-        assert _compile_yara_rules(C.YARA_RULES_DIR) is not None
+        rules, stats = _compile_yara_rules(C.YARA_RULES_DIR)
+        assert rules is not None
+        assert stats["rules_loaded"] >= 1
+        assert "bundled" in stats["sources"]
 
 
 class TestYaraExternals:

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -53,7 +53,7 @@ def test_sink_setup_applies_migrations(tmp_path):
     Sink(create_engine(f"sqlite:///{db}")).setup()
     assert set(_IDX) <= _indexes(db)
     assert "control_state" in _tables(db)
-    assert _version(db) == "0006_file_scan_meta"
+    assert _version(db) == "0007_yara_status"
 
 
 def test_upgrade_stamps_preexisting_create_all_db(tmp_path):
@@ -74,7 +74,7 @@ def test_upgrade_stamps_preexisting_create_all_db(tmp_path):
 
     upgrade_to_head(f"sqlite:///{db}")  # stamps baseline then adds indexes
     assert set(_IDX) <= _indexes(db)
-    assert _version(db) == "0006_file_scan_meta"
+    assert _version(db) == "0007_yara_status"
 
 
 def test_downgrade_then_upgrade_roundtrip(tmp_path):
@@ -107,7 +107,7 @@ def test_control_state_migration_roundtrip(tmp_path):
 
     command.upgrade(_config(f"sqlite:///{db}"), "head")
     assert "control_state" in _tables(db)
-    assert _version(db) == "0006_file_scan_meta"
+    assert _version(db) == "0007_yara_status"
 
     command.downgrade(_config(f"sqlite:///{db}"), "0002_perf_indexes")
     assert "control_state" not in _tables(db)


### PR DESCRIPTION
Answers "how do I see all the YARA info on the dashboard?". The dashboard is a read-only DB reader and the compiled ruleset lives only in the monitor's memory — so the monitor now **persists** a ruleset summary and the dashboard renders it next to the matches.

## Monitor
- `_compile_yara_rules` returns `(rules, stats)`: loaded/skipped counts, skip-reason breakdown, per-source + per-category counts.
- `FileScanCollector` exposes the stats; the **Runner** writes a single-row `yara_status` each cycle (best-effort) via `Sink.write_yara_status`.
- `YaraStatusRow` + migration **0007** (single-row, CREATE IF NOT EXISTS); exported from the package.

## Dashboard
- `queries.yara_status()` + `queries.file_scan()` (matches + verdict, author parsed from rule meta for attribution).
- `/fragments/file-scan` + `_file_scan.html`: a **ruleset card** (N loaded · K skipped · sources · top categories) and a **filterable matches table** (verdict · rule · path · author · source · why). Wired in as a load+60s panel.

## Tests
Panel renders summary + a seeded match (rule/path/author/verdict); empty DB shows the not-compiled state; collector stats asserted; migration head → 0007. **746 pass; ruff clean.**