### PR TITLE
feat(dashboard): browsable, searchable list of all loaded YARA rules

### DIFF
--- a/src/avai/dashboard/app.py
+++ b/src/avai/dashboard/app.py
@@ -60,6 +60,7 @@ from .queries import (
     verdict_counts,
     verdict_timeseries,
     vulnerabilities,
+    yara_rules,
 )
 
 _PKG_DIR = Path(__file__).resolve().parent.parent
@@ -670,6 +671,19 @@ def fragment_file_scan():
             data=(
                 file_scan(s, latest.run_id, verdict=verdict, q=q) if latest else None
             ),
+        )
+
+
+@app.route("/fragments/yara-rules")
+def fragment_yara_rules():
+    q = request.args.get("q", "")
+    source = request.args.get("source", "")
+    page = _int_arg("page", 1)
+    per_page = _int_arg("per_page", 50)
+    with _session() as s:
+        return render_template(
+            "partials/_yara_rules.html",
+            data=yara_rules(s, q=q, source=source, page=page, per_page=per_page),
         )
 
 

--- a/src/avai/dashboard/queries.py
+++ b/src/avai/dashboard/queries.py
@@ -68,6 +68,7 @@ from avai.host_monitor import (
     SystemIntegrityRow,
     UsbDeviceRow,
     WifiStateRow,
+    YaraRuleRow,
     YaraStatusRow,
 )
 
@@ -1700,6 +1701,82 @@ def file_scan(
         "matches": matches,
         "verdict": verdict,
         "q": q,
+    }
+
+
+def yara_rules(
+    session: Session,
+    q: str = "",
+    source: str = "",
+    page: int = 1,
+    per_page: int = 50,
+) -> dict:
+    """Paginated, searchable inventory of the loaded YARA rules so the
+    dashboard can browse every rule (identifier / tags / author / source).
+    Empty when the monitor hasn't persisted the inventory yet."""
+    empty = {
+        "items": [],
+        "total": 0,
+        "page": 1,
+        "per_page": per_page,
+        "total_pages": 1,
+        "q": q,
+        "source": source,
+        "source_options": [],
+    }
+    if YaraRuleRow.__tablename__ not in _existing_tables(session):
+        return empty
+
+    stmt = select(YaraRuleRow)
+    if source:
+        stmt = stmt.where(YaraRuleRow.source == source)
+    if q:
+        like = f"%{q.lower()}%"
+        stmt = stmt.where(
+            or_(
+                func.lower(YaraRuleRow.identifier).like(like),
+                func.lower(func.coalesce(YaraRuleRow.tags, "")).like(like),
+                func.lower(func.coalesce(YaraRuleRow.author, "")).like(like),
+            )
+        )
+    total = session.scalar(select(func.count()).select_from(stmt.subquery())) or 0
+    per_page = max(1, min(per_page, 200))
+    total_pages = max(1, (total + per_page - 1) // per_page)
+    page = max(1, min(page, total_pages))
+    rows = (
+        session.execute(
+            stmt.order_by(YaraRuleRow.identifier)
+            .offset((page - 1) * per_page)
+            .limit(per_page)
+        )
+        .scalars()
+        .all()
+    )
+    source_options = [
+        s
+        for (s,) in session.execute(
+            select(YaraRuleRow.source).distinct().order_by(YaraRuleRow.source)
+        )
+        if s
+    ]
+    return {
+        "items": [
+            {
+                "identifier": r.identifier,
+                "tags": r.tags,
+                "author": r.author,
+                "source": r.source,
+                "category": r.category,
+            }
+            for r in rows
+        ],
+        "total": total,
+        "page": page,
+        "per_page": per_page,
+        "total_pages": total_pages,
+        "q": q,
+        "source": source,
+        "source_options": source_options,
     }
 
 

--- a/src/avai/host_monitor/__init__.py
+++ b/src/avai/host_monitor/__init__.py
@@ -139,6 +139,7 @@ from .models import (
     SystemIntegrityRow,
     UsbDeviceRow,
     WifiStateRow,
+    YaraRuleRow,
     YaraStatusRow,
     _RowBase,
 )
@@ -307,6 +308,7 @@ __all__ = [
     "WATCHED_FILES_LINUX",
     "WifiCollector",
     "WifiStateRow",
+    "YaraRuleRow",
     "YaraStatusRow",
     "_CORRELATED_COLLECTOR",
     "_PKG_DIR",

--- a/src/avai/host_monitor/collectors.py
+++ b/src/avai/host_monitor/collectors.py
@@ -1361,6 +1361,7 @@ def _compile_yara_rules(rules_dir: Path):
         "by_category": {},
         "sources": {},
         "rules_dir": str(rules_dir),
+        "inventory": [],  # one entry per rule, for the dashboard's rule browser
     }
     if not rules_dir.is_dir():
         return None, stats
@@ -1368,11 +1369,14 @@ def _compile_yara_rules(rules_dir: Path):
     skip_reasons: dict[str, int] = {}
     by_category: dict[str, int] = {}
     sources: dict[str, int] = {}
+    inventory: list[dict] = []
     for path in sorted(rules_dir.rglob("*")):
         if path.suffix.lower() not in (".yar", ".yara") or not path.is_file():
             continue
         try:
-            yara.compile(filepath=str(path), externals=_YARA_EXTERNALS)
+            # Iterate the per-file compile (otherwise discarded) to record each
+            # rule's identity for the inventory — no extra compile cost.
+            file_rules = yara.compile(filepath=str(path), externals=_YARA_EXTERNALS)
         except yara.Error as exc:
             reason = "needs crypto-enabled yara" if _crypto_hint(exc) else "other"
             skip_reasons[reason] = skip_reasons.get(reason, 0) + 1
@@ -1394,12 +1398,23 @@ def _compile_yara_rules(rules_dir: Path):
         by_category[category] = by_category.get(category, 0) + 1
         source = _rule_source(path, rules_dir)
         sources[source] = sources.get(source, 0) + 1
+        for rule in file_rules:
+            inventory.append(
+                {
+                    "identifier": rule.identifier,
+                    "tags": " ".join(rule.tags),
+                    "author": str((rule.meta or {}).get("author") or ""),
+                    "source": source,
+                    "category": category,
+                }
+            )
     stats.update(
         files_loaded=len(filepaths),
         files_skipped=sum(skip_reasons.values()),
         skip_reasons=skip_reasons,
         by_category=by_category,
         sources=sources,
+        inventory=inventory,
     )
     if not filepaths:
         return None, stats

--- a/src/avai/host_monitor/models.py
+++ b/src/avai/host_monitor/models.py
@@ -378,6 +378,22 @@ class YaraStatusRow(Base):
     by_category_json: Mapped[Optional[str]]  # {"apt": 315, "gen": 170, ...}
 
 
+class YaraRuleRow(Base):
+    """One row per compiled YARA rule — the loadable inventory the dashboard
+    lets you browse. Rewritten by the monitor whenever the rule count
+    changes (ruleset is static within a process)."""
+
+    __tablename__ = "yara_rule"
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    identifier: Mapped[str] = mapped_column(index=True)
+    tags: Mapped[Optional[str]]
+    author: Mapped[Optional[str]]
+    source: Mapped[Optional[str]] = mapped_column(
+        index=True
+    )  # bundled / signature-base
+    category: Mapped[Optional[str]] = mapped_column(index=True)  # apt / gen / …
+
+
 class FileScanRow(_RowBase):
     __tablename__ = "file_scan"
     path: Mapped[str] = mapped_column(index=True)

--- a/src/avai/host_monitor/runner.py
+++ b/src/avai/host_monitor/runner.py
@@ -569,6 +569,7 @@ class Runner:
             return
         try:
             self.sink.write_yara_status(stats)
+            self.sink.write_yara_rules(stats.get("inventory") or [])
         except Exception as exc:  # noqa: BLE001
             LOG.warning("yara_status: write failed: %s", exc)
 

--- a/src/avai/host_monitor/sink.py
+++ b/src/avai/host_monitor/sink.py
@@ -43,6 +43,7 @@ from .models import (
     RiskScoreRow,
     StreamingSession,
     SystemIntegrityRow,
+    YaraRuleRow,
     YaraStatusRow,
     _RowBase,
 )
@@ -553,6 +554,20 @@ class Sink:
                     by_category_json=json.dumps(stats.get("by_category") or {}),
                 )
             )
+            session.commit()
+
+    def write_yara_rules(self, inventory: list[dict]) -> None:
+        """Replace the browsable rule inventory. Skipped when the row count
+        already matches — the ruleset is static within a monitor process, so
+        this rewrites once (on first cycle / after a restart with changes)
+        rather than every cycle."""
+        with Session(self.engine) as session:
+            current = session.scalar(select(func.count()).select_from(YaraRuleRow))
+            if current == len(inventory):
+                return
+            session.execute(delete(YaraRuleRow))
+            if inventory:
+                session.execute(sqlite_insert(YaraRuleRow), inventory)
             session.commit()
 
     def database_size_bytes(self) -> int:

--- a/src/avai/migrations/versions/0008_yara_rule.py
+++ b/src/avai/migrations/versions/0008_yara_rule.py
@@ -1,0 +1,49 @@
+"""yara_rule — browsable inventory of compiled YARA rules
+
+One row per loaded rule (identifier / tags / author / source / category) so
+the dashboard can list and search every available rule. Rewritten by the
+monitor when the rule count changes.
+
+CREATE TABLE / INDEX IF NOT EXISTS so it's a no-op on a fresh create_all DB
+and a real create on an incrementally-migrated one.
+
+Revision ID: 0008_yara_rule
+Revises: 0007_yara_status
+Create Date: 2026-06-17
+"""
+
+from alembic import op
+
+revision = "0008_yara_rule"
+down_revision = "0007_yara_status"
+branch_labels = None
+depends_on = None
+
+_YARA_RULE = """
+CREATE TABLE IF NOT EXISTS yara_rule (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    identifier VARCHAR NOT NULL,
+    tags VARCHAR,
+    author VARCHAR,
+    source VARCHAR,
+    category VARCHAR
+)
+"""
+
+_INDEXES = [
+    ("ix_yara_rule_identifier", "yara_rule", "identifier"),
+    ("ix_yara_rule_source", "yara_rule", "source"),
+    ("ix_yara_rule_category", "yara_rule", "category"),
+]
+
+
+def upgrade() -> None:
+    op.execute(_YARA_RULE)
+    for name, table, col in _INDEXES:
+        op.execute(f"CREATE INDEX IF NOT EXISTS {name} ON {table} ({col})")
+
+
+def downgrade() -> None:
+    for name, _table, _col in _INDEXES:
+        op.execute(f"DROP INDEX IF EXISTS {name}")
+    op.execute("DROP TABLE IF EXISTS yara_rule")

--- a/src/avai/templates/dashboard.html
+++ b/src/avai/templates/dashboard.html
@@ -307,6 +307,12 @@
              hx-trigger="load, every 60s"
              hx-swap="innerHTML"></section>
 
+    {# ---------- YARA rules browser (the loaded ruleset) ---------- #}
+    <section id="yara-rules-panel"
+             hx-get="/fragments/yara-rules"
+             hx-trigger="load"
+             hx-swap="innerHTML"></section>
+
     {# ---------- auth events (unified log stream) ---------- #}
     <section id="auth-events"
              hx-get="/fragments/auth-events"

--- a/src/avai/templates/partials/_yara_rules.html
+++ b/src/avai/templates/partials/_yara_rules.html
@@ -1,0 +1,116 @@
+{% from "partials/_macros.html" import card_header %}
+
+{# Browsable inventory of every loaded YARA rule — searchable by identifier /
+   tag / author, filterable by source, paginated. Fed by the yara_rule table
+   the monitor writes when it compiles the ruleset. #}
+
+{% set hx = 'hx-get="/fragments/yara-rules" hx-target="#yara-rules" hx-swap="innerHTML" hx-include="#yara-rules-filters"' %}
+
+<div id="yara-rules" class="bg-slate-900 border border-slate-800 rounded-lg p-5">
+  {{ card_header("YARA rules — browse the loaded ruleset") }}
+
+  {# ----- filter bar ----- #}
+  <form id="yara-rules-filters"
+        class="mb-3 flex flex-wrap items-center gap-2 text-xs"
+        onsubmit="return false;">
+    <input type="hidden" name="page" value="{{ data.page }}">
+    <input type="search"
+           name="q"
+           value="{{ data.q }}"
+           placeholder="search rule / tag / author"
+           aria-label="search YARA rules by identifier, tag or author"
+           autocomplete="off"
+           class="bg-slate-800 border border-slate-700 rounded px-2 py-1 w-64 focus:outline-none focus:border-slate-500 placeholder:text-slate-600"
+           {{ hx | safe }}
+           hx-vals='{"page": 1}'
+           hx-trigger="keyup changed delay:300ms, search">
+
+    <select name="source"
+            aria-label="filter YARA rules by source"
+            class="bg-slate-800 border border-slate-700 rounded px-2 py-1 focus:outline-none focus:border-slate-500"
+            {{ hx | safe }}
+            hx-vals='{"page": 1}'
+            hx-trigger="change">
+      <option value="" {% if data.source == "" %}selected{% endif %}>all sources</option>
+      {% for s in data.source_options %}
+        <option value="{{ s }}" {% if data.source == s %}selected{% endif %}>{{ s }}</option>
+      {% endfor %}
+    </select>
+
+    <select name="per_page"
+            aria-label="rules per page"
+            class="bg-slate-800 border border-slate-700 rounded px-2 py-1 focus:outline-none focus:border-slate-500"
+            {{ hx | safe }}
+            hx-vals='{"page": 1}'
+            hx-trigger="change">
+      {% for n in [25, 50, 100, 200] %}
+        <option value="{{ n }}" {% if n == data.per_page %}selected{% endif %}>{{ n }} / page</option>
+      {% endfor %}
+    </select>
+
+    <span class="text-slate-500 ml-auto">
+      {% if data.total %}
+        {{ (data.page - 1) * data.per_page + 1 }}–{{ (data.page - 1) * data.per_page + data["items"]|length }}
+        of {{ "{:,}".format(data.total) }}
+      {% else %}0{% endif %} rules
+    </span>
+  </form>
+
+  {% if data["items"] %}
+    <div class="overflow-x-auto">
+    <table class="w-full text-xs">
+      <thead>
+        <tr class="text-slate-500 uppercase tracking-wider text-[10px]">
+          <th class="text-left font-semibold pb-2">rule</th>
+          <th class="text-left font-semibold pb-2">tags</th>
+          <th class="text-left font-semibold pb-2">source</th>
+          <th class="text-left font-semibold pb-2">category</th>
+          <th class="text-left font-semibold pb-2">author</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-slate-800/80">
+        {% for r in data["items"] %}
+          <tr class="hover:bg-slate-800/40 transition-colors">
+            <td class="py-2 font-mono text-slate-200 break-all">{{ r.identifier }}</td>
+            <td class="py-2 text-slate-400">{{ r.tags or "—" }}</td>
+            <td class="py-2 text-slate-500">{{ r.source or "—" }}</td>
+            <td class="py-2 text-slate-500 font-mono">{{ r.category or "—" }}</td>
+            <td class="py-2 text-slate-400 break-all">{{ r.author or "—" }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    </div>
+
+    {# ----- pagination ----- #}
+    <div class="pt-3 mt-2 border-t border-slate-800 flex items-center justify-between text-xs">
+      <button type="button"
+              class="px-3 py-1 rounded border border-slate-700 text-slate-300 hover:bg-slate-800 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+              {% if data.page <= 1 %}disabled{% endif %}
+              {{ hx | safe }}
+              hx-vals='{"page": {{ data.page - 1 }}}'>← prev</button>
+
+      <div class="flex items-center gap-2 text-slate-400">
+        <span>page</span>
+        <span class="font-mono tabular-nums text-slate-200">{{ data.page }}</span>
+        <span>of</span>
+        <span class="font-mono tabular-nums">{{ data.total_pages }}</span>
+      </div>
+
+      <button type="button"
+              class="px-3 py-1 rounded border border-slate-700 text-slate-300 hover:bg-slate-800 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+              {% if data.page >= data.total_pages %}disabled{% endif %}
+              {{ hx | safe }}
+              hx-vals='{"page": {{ data.page + 1 }}}'>next →</button>
+    </div>
+  {% else %}
+    <div class="text-slate-500 text-xs italic">
+      {% if data.q or data.source %}
+        no rules match the current filters.
+      {% else %}
+        no rule inventory yet — wait for a collection cycle to compile the
+        ruleset, or fetch a pack with <span class="font-mono">scripts/update_rules.py</span>.
+      {% endif %}
+    </div>
+  {% endif %}
+</div>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -412,6 +412,48 @@ class TestDashboardEndpoints:
         body = client.get("/fragments/file-scan").data.decode()
         assert "hasn't compiled" in body  # graceful empty state
 
+    def test_yara_rules_browser_lists_searches_and_filters(self, client):
+        from avai.host_monitor import Sink
+
+        Sink(_engine_rw(app.config["DB_PATH"])).write_yara_rules(
+            [
+                {
+                    "identifier": "APT_Backdoor_Foo",
+                    "tags": "APT",
+                    "author": "Florian Roth",
+                    "source": "signature-base",
+                    "category": "apt",
+                },
+                {
+                    "identifier": "eicar_test_file",
+                    "tags": "",
+                    "author": "avai",
+                    "source": "bundled",
+                    "category": "eicar",
+                },
+            ]
+        )
+        # lists all rules + the source filter options
+        body = client.get("/fragments/yara-rules").data.decode()
+        assert "APT_Backdoor_Foo" in body
+        assert "eicar_test_file" in body
+        assert "signature-base" in body  # source filter option
+        assert "of 2" in body and "rules" in body  # total count (1–2 of 2 rules)
+
+        # search narrows by identifier
+        s = client.get("/fragments/yara-rules?q=backdoor").data.decode()
+        assert "APT_Backdoor_Foo" in s
+        assert "eicar_test_file" not in s
+
+        # source filter narrows
+        f = client.get("/fragments/yara-rules?source=bundled").data.decode()
+        assert "eicar_test_file" in f
+        assert "APT_Backdoor_Foo" not in f
+
+    def test_yara_rules_empty_db_shows_no_inventory(self, client):
+        body = client.get("/fragments/yara-rules").data.decode()
+        assert "no rule inventory yet" in body
+
     def test_network_panel_is_an_accessible_tablist(self, client):
         # WAI-ARIA tabs pattern: the tab strip must be a tablist of tabs that
         # control the shared panel, with exactly one tab pre-selected.

--- a/tests/test_file_scan.py
+++ b/tests/test_file_scan.py
@@ -194,6 +194,13 @@ class TestFileScanCollector:
         assert rules is not None
         assert stats["rules_loaded"] >= 1
         assert "bundled" in stats["sources"]
+        # inventory carries one entry per rule, tagged with source/category
+        assert len(stats["inventory"]) == stats["rules_loaded"]
+        eicar = next(
+            e for e in stats["inventory"] if e["identifier"] == "eicar_test_file"
+        )
+        assert eicar["source"] == "bundled"
+        assert eicar["category"] == "eicar"
 
 
 class TestYaraExternals:

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -53,7 +53,7 @@ def test_sink_setup_applies_migrations(tmp_path):
     Sink(create_engine(f"sqlite:///{db}")).setup()
     assert set(_IDX) <= _indexes(db)
     assert "control_state" in _tables(db)
-    assert _version(db) == "0007_yara_status"
+    assert _version(db) == "0008_yara_rule"
 
 
 def test_upgrade_stamps_preexisting_create_all_db(tmp_path):
@@ -74,7 +74,7 @@ def test_upgrade_stamps_preexisting_create_all_db(tmp_path):
 
     upgrade_to_head(f"sqlite:///{db}")  # stamps baseline then adds indexes
     assert set(_IDX) <= _indexes(db)
-    assert _version(db) == "0007_yara_status"
+    assert _version(db) == "0008_yara_rule"
 
 
 def test_downgrade_then_upgrade_roundtrip(tmp_path):
@@ -107,7 +107,7 @@ def test_control_state_migration_roundtrip(tmp_path):
 
     command.upgrade(_config(f"sqlite:///{db}"), "head")
     assert "control_state" in _tables(db)
-    assert _version(db) == "0007_yara_status"
+    assert _version(db) == "0008_yara_rule"
 
     command.downgrade(_config(f"sqlite:///{db}"), "0002_perf_indexes")
     assert "control_state" not in _tables(db)


### PR DESCRIPTION
Adds a full, navigable inventory of the loaded ruleset — the File Scan panel showed counts, this lets you browse every rule.

## Monitor
- `_compile_yara_rules` builds a per-rule inventory (identifier, tags, author, source, category) by iterating each per-file compile that was previously discarded — **no extra compile cost**.
- `YaraRuleRow` + migration **0008** (indexed on identifier/source/category). `Sink.write_yara_rules` rewrites only when the rule count changes (ruleset is static within a process → writes once per run). The Runner persists it with `yara_status`.

## Dashboard
- `queries.yara_rules()`: paginated + searchable (identifier/tag/author) + source filter.
- `/fragments/yara-rules` + `_yara_rules.html`: search box, source + per-page selectors, rules table, prev/next pagination. New panel below File Scan.

## Verified
End-to-end against the real ruleset: **5,292 rules** browse, paginate, and search (`eicar`); source filter narrows bundled vs signature-base. 748 tests pass; ruff clean.