### PR TITLE
landing: make docker run the primary install method

### DIFF
--- a/web/components/landing/CopyButton.tsx
+++ b/web/components/landing/CopyButton.tsx
@@ -2,9 +2,7 @@
 
 import { useState } from "react";
 
-const INSTALL = `pip install 'avai-monitor[judge]'
-sudo avai monitor &
-avai dashboard`;
+const INSTALL = `docker run -p 8765:8765 -v "$PWD":/data iklob1/avai`;
 
 export function CopyButton() {
   const [copied, setCopied] = useState(false);

--- a/web/components/landing/Hero.tsx
+++ b/web/components/landing/Hero.tsx
@@ -32,15 +32,20 @@ export function Hero() {
       <div className="mx-auto mt-8 max-w-xl">
         <div className="card flex items-start justify-between gap-3 p-4 text-left">
           <pre className="mono overflow-x-auto text-sm text-slate-200">
-            <code>{`$ pip install 'avai-monitor[judge]'
-$ sudo avai monitor &
-$ avai dashboard`}</code>
+            <code>{`$ docker run -p 8765:8765 -v "$PWD":/data iklob1/avai
+# dashboard on http://localhost:8765`}</code>
           </pre>
           <CopyButton />
         </div>
+        <p className="mx-auto mt-3 max-w-xl text-sm text-slate-500">
+          Prefer native?{" "}
+          <code className="mono text-slate-400">
+            pip install &apos;avai-monitor[judge]&apos;
+          </code>
+        </p>
         <a
           href="https://github.com/iklobato/avai"
-          className="mt-3 inline-block text-sm text-accent hover:underline"
+          className="mt-2 inline-block text-sm text-accent hover:underline"
         >
           or read the source →
         </a>

--- a/web/components/landing/sections.tsx
+++ b/web/components/landing/sections.tsx
@@ -374,16 +374,16 @@ export function AiExpert() {
 export function GetStarted() {
   const options = [
     {
-      title: "pip (macOS or Linux)",
-      tag: "recommended",
-      body: "pip install 'avai-monitor[judge]'",
-    },
-    {
       title: "Docker",
-      tag: "",
+      tag: "recommended",
       body: 'docker run -p 8765:8765 -v "$PWD":/data iklob1/avai',
     },
     { title: "docker compose", tag: "", body: "docker compose up -d" },
+    {
+      title: "pip (macOS or Linux)",
+      tag: "",
+      body: "pip install 'avai-monitor[judge]'",
+    },
   ];
   const recipes = [
     {
@@ -411,7 +411,7 @@ export function GetStarted() {
     <Section
       id="install"
       title="One command to run it."
-      subtitle="Install with pip or Docker, then open the dashboard."
+      subtitle="One `docker run` — or install natively with pip — then open the dashboard."
     >
       <div className="grid gap-4 md:grid-cols-3">
         {options.map((o) => (


### PR DESCRIPTION
## What

Realigns the marketing landing page with the README so **`docker run` is the featured way to run avai**. The README already treats Docker as the primary path (pip is the secondary "native install"), but the landing page still led with pip.

## Why

Asked to restore Docker as the primary run method. Investigation showed `docker run` was never actually removed — it's fully present in the Dockerfiles, README (sections 1–6), and even the landing's install grid. The only drift was *emphasis*: the landing hero, copy button, and get-started grid led with pip while the README led with Docker. This commit removes that inconsistency.

## Changes (landing page only)

- **`Hero.tsx`** — lead code block + copy button now show `docker run -p 8765:8765 -v "$PWD":/data iklob1/avai`; pip demoted to a small secondary "Prefer native?" line.
- **`CopyButton.tsx`** — clipboard payload now copies the `docker run` command (kept in sync with the hero).
- **`sections.tsx`** — install grid reordered to **Docker (`recommended`) → docker compose → pip**; subtitle updated to "One `docker run` — or install natively with pip".

## Deliberately untouched

- `README.md` — already Docker-first.
- `CHANGELOG.md` (history), `av-features.md` (no install section), `web/README.md` (the app's own dev setup), Dockerfile/compose (already correct).

## Verification caveat

`web/node_modules` is not installed in this worktree, so `tsc` / `next lint` were **not** run. Changes are minimal JSX/string edits and prettier reparsed/reformatted `Hero.tsx` cleanly (confirms valid syntax), but this is not a full typecheck. Happy to `npm install` + typecheck on request.