### PR TITLE
feat(blog): link all article images to the homepage

### DIFF
--- a/web/app/blog/[slug]/page.tsx
+++ b/web/app/blog/[slug]/page.tsx
@@ -115,23 +115,27 @@ export default async function BlogPost({ params }: { params: Params }) {
           <p className="mt-2 text-sm text-slate-500">{article.dateLabel}</p>
         ) : null}
         {article.heroImage ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            className="mt-6 w-full rounded-lg"
-            src={article.heroImage}
-            alt={article.heroAlt ?? article.title}
-          />
+          <Link href="/" className="mt-6 block" aria-label="Go to homepage">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              className="w-full rounded-lg"
+              src={article.heroImage}
+              alt={article.heroAlt ?? article.title}
+            />
+          </Link>
         ) : null}
         <div className="mt-6">
           <ArticleBody html={article.contentHtml} />
         </div>
         {article.infographic ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            className="mt-8 w-full rounded-lg"
-            src={article.infographic}
-            alt={`${article.title} infographic`}
-          />
+          <Link href="/" className="mt-8 block" aria-label="Go to homepage">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              className="w-full rounded-lg"
+              src={article.infographic}
+              alt={`${article.title} infographic`}
+            />
+          </Link>
         ) : null}
       </article>
     </main>

--- a/web/lib/sanitize.ts
+++ b/web/lib/sanitize.ts
@@ -49,9 +49,33 @@ const OPTIONS: sanitizeHtml.IOptions = {
   disallowedTagsMode: "discard",
 };
 
+// Every article image should link to the homepage. We wrap bare <img> tags in
+// an anchor AFTER sanitizing (the markup is ours, so it isn't re-stripped).
+const HOME_HREF = "/";
+const IMG_TAG = /<img\b[^>]*>/gi;
+const OPEN_A = /<a\b[^>]*>/gi;
+const CLOSE_A = /<\/a\s*>/gi;
+
+// True when the character offset falls inside an open <a>…</a> region. Used to
+// skip images already linked, since nesting anchors is invalid HTML.
+function isInsideAnchor(html: string, offset: number): boolean {
+  const region = html.slice(0, offset);
+  const opens = (region.match(OPEN_A) ?? []).length;
+  const closes = (region.match(CLOSE_A) ?? []).length;
+  return opens > closes;
+}
+
+function wrapImagesWithHomeLink(html: string): string {
+  return html.replace(IMG_TAG, (tag, offset: number) =>
+    isInsideAnchor(html, offset)
+      ? tag
+      : `<a href="${HOME_HREF}" class="cursor-pointer" aria-label="Go to homepage">${tag}</a>`,
+  );
+}
+
 export function sanitizeArticle(html: string | null | undefined): string {
   if (!html) {
     return "";
   }
-  return sanitizeHtml(html, OPTIONS);
+  return wrapImagesWithHomeLink(sanitizeHtml(html, OPTIONS));
 }


### PR DESCRIPTION
## What
Make every image in an article link to the site homepage (`/`) — same tab — for both AutoSEO and Soro posts (they share the render path).

Covers all three image locations on the article detail page (`app/blog/[slug]/page.tsx`):
- Hero image
- In-body content images (inside sanitized HTML)
- Infographic

The blog listing renders no images, so it needed no change.

## How
- `lib/sanitize.ts`: `sanitizeArticle()` wraps each bare `<img>` in `<a href="/">` after sanitizing (the markup is ours, so it isn't re-stripped). Images already inside an `<a>` are skipped — avoids invalid nested anchors and preserves intentional links.
- `app/blog/[slug]/page.tsx`: hero and infographic `<img>` wrapped in a Next `<Link href="/">`.

## Verification
- `npm run build` passes (compile + TypeScript clean).
- Isolated test of the wrap logic confirms: bare images wrapped, self-closed/attribute variants handled, already-linked images skipped, mixed and image-free HTML correct.
- Manual click-through recommended in `npm run dev` (no automated test runner in this project).

## Notes
- Already-linked images keep their original destination rather than being force-rewritten to `/`.
- `npm run lint` is broken independently of this change (Next 16 misparses `next lint`); left untouched as out of scope.