### PR TITLE
feat(host_monitor): deepen the LLM judgement pipeline

### DIFF
--- a/src/avai/dashboard/app.py
+++ b/src/avai/dashboard/app.py
@@ -13,13 +13,14 @@ from flask import Flask, abort, jsonify, render_template, request
 from sqlalchemy import desc, select
 from sqlalchemy.orm import Session
 
-from avai.host_monitor import CollectionRun
+from avai.host_monitor import CollectionRun, FeedbackLabel
 
 from .control import (
     bump_scan_now,
     monitor_alive,
     queue_command,
     read_control_state,
+    record_feedback,
     set_collector,
     set_paused,
     set_settings,
@@ -835,3 +836,27 @@ def control_maintenance(action):
         abort(400)
     queue_command(action)
     return _control_panel()
+
+
+_FEEDBACK_LABELS = {label.value for label in FeedbackLabel}
+
+
+@app.route("/feedback/<collector>/<content_hash>/<label>", methods=["POST"])
+@require_control_token
+def feedback_record(collector, content_hash, label):
+    """Record an operator correction on a finding. The monitor applies it to
+    the verdict and feeds it back to the judge next cycle, so the on-screen
+    verdict updates on the following refresh (not instantly)."""
+    if collector not in COLLECTOR_MODELS or label not in _FEEDBACK_LABELS:
+        abort(400)
+    record_feedback(
+        content_hash=content_hash,
+        collector=collector,
+        label=label,
+        note=(request.form.get("note", "").strip() or None),
+        artifact=(request.form.get("artifact", "").strip() or None),
+    )
+    return (
+        '<span class="text-emerald-400 text-[10px] uppercase tracking-wider">'
+        "✓ recorded — applies next cycle</span>"
+    )

--- a/src/avai/dashboard/control.py
+++ b/src/avai/dashboard/control.py
@@ -17,7 +17,7 @@ from sqlalchemy import create_engine, event, update
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.orm import Session
 
-from avai.host_monitor import ControlState
+from avai.host_monitor import ControlState, FeedbackRow
 
 _write_engine_cache: dict[str, object] = {}
 _write_engine_lock = threading.Lock()
@@ -99,6 +99,45 @@ def set_collector(name: str, enabled: bool) -> None:
         }
         current.discard(name) if enabled else current.add(name)
         row.disabled_collectors = ",".join(sorted(current)) or None
+        session.commit()
+
+
+def record_feedback(
+    *,
+    content_hash: str,
+    collector: str,
+    label: str,
+    note: str | None,
+    artifact: str | None,
+) -> None:
+    """Persist an operator correction on a finding (latest-wins per finding).
+    The monitor picks it up next cycle — applies it to the verdict and feeds
+    it back to the judge. This is the one telemetry-adjacent table the
+    dashboard writes; the monitor remains the sole writer of findings."""
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    with Session(_write_engine()) as session:
+        session.execute(
+            sqlite_insert(FeedbackRow)
+            .values(
+                content_hash=content_hash,
+                collector=collector,
+                label=label,
+                note=note,
+                artifact=artifact,
+                created_at=now,
+                applied=0,
+            )
+            .on_conflict_do_update(
+                index_elements=["content_hash", "collector"],
+                set_={
+                    "label": label,
+                    "note": note,
+                    "artifact": artifact,
+                    "created_at": now,
+                    "applied": 0,
+                },
+            )
+        )
         session.commit()
 
 

--- a/src/avai/dashboard/queries.py
+++ b/src/avai/dashboard/queries.py
@@ -68,6 +68,7 @@ from avai.host_monitor import (
     SystemIntegrityRow,
     UsbDeviceRow,
     WifiStateRow,
+    YaraCoverageRow,
     YaraStatusRow,
 )
 
@@ -116,6 +117,7 @@ COLLECTOR_MODELS = {
 
 DISPLAY_FIELDS: dict[str, tuple[str, ...]] = {
     "processes": ("name", "exe"),
+    "network_connections": ("raddr_ip", "raddr_port"),
     "network_flows": ("dst_ip", "dst_port"),
     "dns_queries": ("qname", "qtype"),
     "ssh_authorized_keys": ("owner", "fingerprint"),
@@ -355,14 +357,62 @@ def risk_trend(session: Session, limit: int = 30) -> list[int]:
 _VULN_SOURCES = ("osv", "nvd", "cisa_kev", "github_advisory", "endoflife")
 
 
+def _normalize_software(name: str) -> str:
+    """Reduce a software/package/exe string to a comparable base token:
+    drop the ``@version`` suffix, take the path basename, strip a ``.app``
+    suffix. ``"openssl@3.0.2"`` → ``"openssl"``; ``"/usr/sbin/nginx"`` →
+    ``"nginx"``; ``"Firefox.app"`` → ``"firefox"``."""
+    base = str(name or "").split("@", 1)[0].strip().lower()
+    base = base.rsplit("/", 1)[-1]
+    if base.endswith(".app"):
+        base = base[:-4]
+    return base
+
+
+def _software_presence(session: Session, run_id) -> tuple[set, set]:
+    """``(running, exposed)`` normalized software names for ``run_id``:
+    ``running`` from the process snapshot (name + exe basename), ``exposed``
+    from the listening-port owners. Used to tell whether a vulnerable package
+    is actually present and reachable on the host, not just installed."""
+    running: set = set()
+    exposed: set = set()
+    if run_id is None:
+        return running, exposed
+    present = _existing_tables(session)
+    if "processes" in present:
+        for name, exe in session.execute(
+            select(ProcessRow.name, ProcessRow.exe).where(ProcessRow.run_id == run_id)
+        ).all():
+            if name:
+                running.add(_normalize_software(name))
+            if exe:
+                running.add(_normalize_software(exe))
+    if "listening_ports" in present:
+        for pname in session.execute(
+            select(ListeningPortRow.process_name).where(
+                ListeningPortRow.run_id == run_id
+            )
+        ).scalars():
+            if pname:
+                exposed.add(_normalize_software(pname))
+    running.discard("")
+    exposed.discard("")
+    return running, exposed
+
+
 def vulnerabilities(session: Session) -> list[dict]:
     """Aggregate the CVE / EOL evidence the enrichment chain already
-    collected into a prioritised 'patch me' list (KEV → has-CVE → EOL).
-    Reads the enrichment_evidence cache; [] if it isn't present."""
+    collected into a prioritised 'patch me' list. Each item is flagged with
+    whether the vulnerable software is actually ``running`` and/or ``exposed``
+    (listening) on the host, and the list is prioritised
+    KEV → exposed → running → CVSS → has-CVE → EOL — actively-exploited and
+    reachable first. Reads the enrichment_evidence cache; [] if absent."""
     if "enrichment_evidence" not in _existing_tables(session):
         return []
     from avai.enrichers.cache import register_schema
 
+    latest = latest_run(session)
+    running, exposed = _software_presence(session, latest.run_id if latest else None)
     model = register_schema(Base)
     rows = session.execute(
         select(
@@ -425,6 +475,7 @@ def vulnerabilities(session: Session) -> list[dict]:
         ]
         kev = any(c["kev"] for c in cves)
         cvss = max((c["cvss"] for c in cves if c["cvss"] is not None), default=None)
+        base = _normalize_software(ival)
         items.append(
             {
                 "software": ival,
@@ -434,12 +485,18 @@ def vulnerabilities(session: Session) -> list[dict]:
                 "cvss": cvss,
                 "eol": eol,
                 "summary": summary or "",
+                # Is this vulnerable software actually present on the host?
+                "running": base in running,
+                "exposed": base in exposed,
             }
         )
-    # prioritise: actively-exploited (KEV) → highest CVSS → has-CVE → EOL
+    # prioritise: actively-exploited (KEV) → reachable (exposed) → present
+    # (running) → highest CVSS → has-CVE → EOL.
     items.sort(
         key=lambda i: (
             not i["kev"],
+            not i["exposed"],
+            not i["running"],
             -(i["cvss"] or 0.0),
             not i["cves"],
             not i["eol"],
@@ -1697,9 +1754,32 @@ def file_scan(
         ]
     return {
         "status": yara_status(session),
+        "coverage": yara_coverage(session),
         "matches": matches,
         "verdict": verdict,
         "q": q,
+    }
+
+
+def yara_coverage(session: Session) -> "dict | None":
+    """The most recent LLM assessment of how well the loaded ruleset covers
+    this host (posture / headline / summary / gaps / recommendations). None
+    when the assessor has never run or its table predates this DB."""
+    if YaraCoverageRow.__tablename__ not in _existing_tables(session):
+        return None
+    row = session.execute(
+        select(YaraCoverageRow).order_by(desc(YaraCoverageRow.created_at)).limit(1)
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+    return {
+        "posture": row.posture,
+        "headline": row.headline,
+        "summary": row.summary,
+        "gaps": json.loads(row.gaps_json or "[]"),
+        "recommendations": json.loads(row.recommendations_json or "[]"),
+        "created_at": row.created_at,
+        "model": row.model,
     }
 
 

--- a/src/avai/enrichers/indicators.py
+++ b/src/avai/enrichers/indicators.py
@@ -126,11 +126,17 @@ class ProcessExtractor(IndicatorExtractor):
 
 class NetworkConnectionExtractor(IndicatorExtractor):
     def extract(self, row):
-        raddr = row.get("raddr")
-        if isinstance(raddr, str) and ":" in raddr:
-            host = raddr.rsplit(":", 1)[0]
-            if _is_ipv4(host) and not _is_private_ip(host):
-                yield Indicator(IndicatorType.IPV4, host, context={"raddr": raddr})
+        # The collector emits raddr_ip/raddr_port; older/synthetic rows may
+        # carry a combined "ip:port" raddr string — support both. IPv4-only
+        # by design (bracketed-IPv6 raddr strings parse to a non-IPv4 host
+        # and are skipped).
+        host = row.get("raddr_ip")
+        if not host:
+            raddr = row.get("raddr")
+            if isinstance(raddr, str) and ":" in raddr:
+                host = raddr.rsplit(":", 1)[0]
+        if isinstance(host, str) and _is_ipv4(host) and not _is_private_ip(host):
+            yield Indicator(IndicatorType.IPV4, host, context={"raddr_ip": host})
 
 
 class NetworkFlowExtractor(IndicatorExtractor):

--- a/src/avai/host_monitor/__init__.py
+++ b/src/avai/host_monitor/__init__.py
@@ -79,7 +79,7 @@ from .constants import (
     WATCHED_FILES,
     WATCHED_FILES_LINUX,
 )
-from .enums import Browser, LaunchScope, ThreatCategory, Verdict
+from .enums import Browser, FeedbackLabel, LaunchScope, ThreatCategory, Verdict
 from .hosts import FilesystemLayout, Host, HostFactory, PrivilegedAccounts
 from .judge import (
     AnthropicOAuthClient,
@@ -106,6 +106,7 @@ from .models import (
     DiskUsageRow,
     DnsQueryRow,
     DnsResolverRow,
+    FeedbackRow,
     FileIntegrityRow,
     FileScanRow,
     HostResourceRow,
@@ -139,6 +140,7 @@ from .models import (
     SystemIntegrityRow,
     UsbDeviceRow,
     WifiStateRow,
+    YaraCoverageRow,
     YaraRuleRow,
     YaraStatusRow,
     _RowBase,
@@ -217,6 +219,8 @@ __all__ = [
     "DEFAULT_PROMPTS_PATH",
     "DnsQueriesCollector",
     "DnsQueryRow",
+    "FeedbackLabel",
+    "FeedbackRow",
     "DnsResolverRow",
     "FileIntegrityCollector",
     "FileIntegrityRow",
@@ -308,6 +312,7 @@ __all__ = [
     "WATCHED_FILES_LINUX",
     "WifiCollector",
     "WifiStateRow",
+    "YaraCoverageRow",
     "YaraRuleRow",
     "YaraStatusRow",
     "_CORRELATED_COLLECTOR",

--- a/src/avai/host_monitor/collectors.py
+++ b/src/avai/host_monitor/collectors.py
@@ -260,7 +260,13 @@ class ProcessCollector(SnapshotCollector):
 class NetworkConnectionsCollector(SnapshotCollector):
     name = "network_connections"
     model = NetworkConnectionRow
-    judge_enabled = False  # too high churn; aggregate behaviourally instead
+    # Judged on the remote-endpoint identity. Dedup over (remote ip, port,
+    # status) collapses the many sockets to one verdict per peer (judged once
+    # ever via content_hash), and threat-intel for the remote IP is attached
+    # by enrichment. tcpdump `network_flows` cover active outbound traffic;
+    # this catches established/idle remote peers a capture window can miss.
+    # Private/loopback/no-remote rows collapse to a single benign entry.
+    judge_fields = ("raddr_ip", "raddr_port", "status")
 
     def collect(self):
         for c in PsutilConnections.inet():
@@ -1328,6 +1334,57 @@ def _file_type(path: Path) -> str:
     return ""
 
 
+def _redact_one_match(identifier: str, offset: int, data: bytes) -> dict:
+    """Render one matched byte run for the judge: printable runs as ``text``,
+    anything else as ``hex``, truncated to ``YARA_MATCH_STRING_MAX_BYTES`` so
+    a large or binary match can't bloat the prompt/DB or leak a full payload."""
+    raw = bytes(data or b"")
+    truncated = len(raw) > constants.YARA_MATCH_STRING_MAX_BYTES
+    raw = raw[: constants.YARA_MATCH_STRING_MAX_BYTES]
+    printable = sum(1 for b in raw if 0x20 <= b < 0x7F)
+    out = {"id": identifier, "offset": int(offset), "truncated": truncated}
+    if raw and printable / len(raw) >= 0.8:
+        out["text"] = raw.decode("ascii", "replace")
+    else:
+        out["hex"] = raw.hex()
+    return out
+
+
+def _redact_match_strings(match) -> list[dict]:
+    """A bounded, redacted view of the bytes a YARA match fired on.
+
+    Tolerant of both yara-python string-match shapes: the >=4.3 object form
+    (``StringMatch`` with ``.identifier`` + ``.instances`` carrying
+    ``.offset`` / ``.matched_data``) and the legacy ``(offset, identifier,
+    data)`` tuple. Capped at ``YARA_MAX_MATCH_STRINGS`` entries total — a
+    broad rule on a big binary can otherwise report thousands of instances."""
+    cap = constants.YARA_MAX_MATCH_STRINGS
+    out: list[dict] = []
+    for sm in getattr(match, "strings", None) or []:
+        instances = getattr(sm, "instances", None)
+        if instances is not None:  # modern object API
+            identifier = getattr(sm, "identifier", "")
+            for inst in instances:
+                out.append(
+                    _redact_one_match(
+                        identifier,
+                        getattr(inst, "offset", 0),
+                        getattr(inst, "matched_data", b""),
+                    )
+                )
+                if len(out) >= cap:
+                    return out
+        else:  # legacy tuple API: (offset, identifier, data)
+            try:
+                offset, identifier, data = sm
+            except (TypeError, ValueError):
+                continue
+            out.append(_redact_one_match(identifier, offset, data))
+            if len(out) >= cap:
+                return out
+    return out
+
+
 def _rule_source(path: Path, rules_dir: Path) -> str:
     """Label a rule file by where it came from: top-level files are
     ``bundled``; a vendored pack file (``vendor/<name>/…``) is ``<name>``."""
@@ -1579,6 +1636,10 @@ class FileScanCollector(SnapshotCollector):
                 # finding to satisfy the signature-base DRL attribution
                 # obligation and to give the judge/dashboard rule context.
                 "meta_json": json.dumps(m.meta, default=str),
+                # Redacted sample of the bytes that matched — lets the judge
+                # tell a substantive hit from a generic substring (false
+                # positive). Bounded by the YARA_MATCH_STRING* caps.
+                "strings_json": json.dumps(_redact_match_strings(m)),
                 "size": st.st_size,
                 "mtime": st.st_mtime,
                 "scan_source": source,

--- a/src/avai/host_monitor/constants.py
+++ b/src/avai/host_monitor/constants.py
@@ -40,6 +40,14 @@ DEFAULT_BASELINE_MIN_RUNS = 12
 
 _CORRELATED_COLLECTOR = "processes"
 
+# Collector whose findings carry YARA rule context (rule meta + matched
+# strings) the Runner attaches to the judge payload for FP triage.
+_FILE_SCAN_COLLECTOR = "file_scan"
+
+# Persistence collector whose entries are correlated with the runtime
+# behaviour of the process their program spawns (program → pid → story).
+_LAUNCH_ITEM_COLLECTOR = "launch_items"
+
 
 DEFAULT_NARRATIVE_MODEL = DEFAULT_JUDGE_MODEL
 
@@ -221,6 +229,15 @@ YARA_MAX_FILES_PER_CYCLE = 5000
 # payloads are the signal; re-hashing tens of thousands of old downloads
 # every cycle is not (measured: 12 recent vs 72k total).
 YARA_DOWNLOADS_RECENT_DAYS = 7
+
+# When a rule matches, surface a bounded, redacted sample of the bytes that
+# actually matched to the judge so it can tell a substantive hit (a real C2
+# URL / mutex / command line) from a generic substring (a likely false
+# positive). Caps keep binary blobs and pathological match counts out of the
+# prompt and the DB. A broad hunting rule on a big binary can yield thousands
+# of instances; 20 entries at 80 bytes each is enough context to triage.
+YARA_MAX_MATCH_STRINGS = 20
+YARA_MATCH_STRING_MAX_BYTES = 80
 
 # Offline known-bad hash deny-list consumed by LocalHashDenylistEnricher:
 # one hex digest (md5 / sha1 / sha256) per line, '#' comments allowed. An

--- a/src/avai/host_monitor/coverage.py
+++ b/src/avai/host_monitor/coverage.py
@@ -1,0 +1,158 @@
+"""Second-stage LLM that assesses YARA ruleset coverage for the host.
+
+Reads the compiled ruleset summary (count / sources / per-category counts)
+and a compact host profile (platform + inventory counts) and judges whether
+the loaded rules adequately cover THIS host's threat surface — a posture, a
+headline, gaps, and recommendations. Reuses the judge's completion client and
+structured-output path, exactly like :class:`IncidentNarrator`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from string import Template
+from typing import Optional
+
+from .constants import DEFAULT_NARRATIVE_MODEL, LOG
+from .judge import HAS_LITELLM, CompletionClient, build_completion_client
+from .prompts import Prompts
+
+
+class YaraCoverageAssessor:
+    """Second-stage LLM that reads the loaded YARA ruleset + a host profile
+    and returns a structured coverage assessment."""
+
+    SCHEMA_NAME = "submit_coverage"
+    POSTURES = ("well_covered", "partial", "thin")
+
+    @classmethod
+    def _coverage_schema(cls) -> dict:
+        item = {
+            "type": "object",
+            "properties": {
+                "area": {"type": "string"},
+                "action": {"type": "string"},
+                "detail": {"type": "string"},
+            },
+        }
+        return {
+            "type": "object",
+            "properties": {
+                "posture": {"type": "string", "enum": list(cls.POSTURES)},
+                "headline": {"type": "string"},
+                "summary": {"type": "string"},
+                "gaps": {"type": "array", "items": item},
+                "recommendations": {"type": "array", "items": item},
+            },
+            "required": ["posture", "headline", "summary", "gaps", "recommendations"],
+        }
+
+    def __init__(
+        self,
+        prompts: Prompts,
+        model: str = DEFAULT_NARRATIVE_MODEL,
+        temperature: float = 0.2,
+        max_tokens: int = 1024,
+        client: Optional[CompletionClient] = None,
+    ):
+        self.model = model
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self._system = prompts.coverage_system
+        self._user_template = Template(prompts.coverage_user_template)
+        self._client = client or build_completion_client()
+        self._schema = self._coverage_schema()
+
+    @property
+    def auth_mode(self) -> str:
+        return type(self._client).__name__
+
+    def assess(self, ruleset: dict, host: dict) -> Optional[dict]:
+        """Return ``{posture, headline, summary, gaps[], recommendations[]}``
+        or None on failure/empty ruleset. Never raises — a coverage-assessment
+        failure must not abort the cycle."""
+        if not ruleset or not ruleset.get("rules_loaded"):
+            return None
+        user = self._user_template.safe_substitute(
+            ruleset=json.dumps(ruleset, ensure_ascii=False),
+            host=json.dumps(host, ensure_ascii=False),
+        )
+        try:
+            parsed = self._client.complete_structured(
+                model=self.model,
+                system=self._system,
+                user=user,
+                max_tokens=self.max_tokens,
+                temperature=self.temperature,
+                schema=self._schema,
+                schema_name=self.SCHEMA_NAME,
+            )
+        except Exception as exc:
+            LOG.warning(
+                "coverage assessor failed error=%s msg=%s",
+                type(exc).__name__,
+                str(exc)[:200],
+            )
+            return None
+        posture = str(parsed.get("posture") or "").lower()
+        if posture not in self.POSTURES:
+            posture = "partial"
+        headline = str(parsed.get("headline") or "").strip()[:200]
+        summary = str(parsed.get("summary") or "").strip()[:2000]
+        gaps = self._clean_items(parsed.get("gaps"), "area")
+        recommendations = self._clean_items(parsed.get("recommendations"), "action")
+        if not headline or not (summary or gaps):
+            return None
+        return {
+            "posture": posture,
+            "headline": headline,
+            "summary": summary,
+            "gaps": gaps,
+            "recommendations": recommendations,
+        }
+
+    @staticmethod
+    def _clean_items(raw, label_key: str) -> list[dict]:
+        """Normalise a gaps/recommendations array: keep the entries whose
+        label field (``area`` or ``action``) is non-empty, trim the rest."""
+        out: list[dict] = []
+        for it in raw or []:
+            if not isinstance(it, dict):
+                continue
+            label = str(it.get(label_key) or "").strip()
+            if not label:
+                continue
+            out.append(
+                {
+                    label_key: label[:100],
+                    "detail": str(it.get("detail") or "").strip()[:300],
+                }
+            )
+        return out[:12]
+
+
+def build_coverage_assessor(args, prompts: Prompts) -> "Optional[YaraCoverageAssessor]":
+    """Build the coverage assessor when enabled and credentials exist.
+    Returns None (assessment disabled) otherwise — the same credential rule as
+    the judge/narrator, since it needs an LLM client."""
+    if getattr(args, "no_coverage", False):
+        return None
+    if not prompts.coverage_system:
+        LOG.warning("coverage prompt missing from prompts file; assessment disabled")
+        return None
+    has_oauth = bool(os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"))
+    has_api_key = bool(
+        os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    )
+    if not has_oauth and not has_api_key:
+        return None
+    if not has_oauth and not HAS_LITELLM:
+        return None
+    try:
+        assessor = YaraCoverageAssessor(prompts=prompts, model=args.narrative_model)
+    except RuntimeError as exc:
+        LOG.warning("YaraCoverageAssessor unavailable (%s); assessment disabled", exc)
+        return None
+    LOG.info("coverage auth_mode=%s model=%s", assessor.auth_mode, assessor.model)
+    return assessor

--- a/src/avai/host_monitor/enums.py
+++ b/src/avai/host_monitor/enums.py
@@ -29,6 +29,13 @@ class ThreatCategory(StrEnum):
     RECONNAISSANCE = "reconnaissance"
 
 
+class FeedbackLabel(StrEnum):
+    """Operator correction on a finding, fed back into judging."""
+
+    FALSE_POSITIVE = "false_positive"
+    CONFIRMED = "confirmed"
+
+
 class LaunchScope(StrEnum):
     USER_AGENT = "user_agent"
     SYSTEM_AGENT = "system_agent"

--- a/src/avai/host_monitor/investigator.py
+++ b/src/avai/host_monitor/investigator.py
@@ -1,0 +1,154 @@
+"""Deep second pass that re-judges findings the first pass left ``unknown``.
+
+The per-collector judge decides in one shot from a bounded context. When it
+returns ``unknown`` (insufficient information), this stage re-judges the
+artifact with a RICHER, deliberately-gathered bundle — full-history behaviour
+correlation, all threat-intel evidence, and the host's other active findings —
+so "I can't tell" turns into a committed verdict more often.
+
+This is the bounded form of an investigator: it gathers a fixed deeper context
+and re-judges once. A fully agentic version (the LLM choosing which tools to
+call over multiple turns) would need a multi-turn client abstraction the
+codebase doesn't have yet; that's a deliberate follow-up.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from string import Template
+from typing import Optional
+
+from .constants import DEFAULT_JUDGE_MODEL, LOG
+from .enums import ThreatCategory, Verdict
+from .judge import HAS_LITELLM, CompletionClient, build_completion_client
+from .prompts import Prompts
+from .runtime import Coerce
+
+
+class UnknownFindingInvestigator:
+    """Re-judge a single ``unknown`` finding given a richer context bundle."""
+
+    SCHEMA_NAME = "submit_investigation"
+
+    @classmethod
+    def _investigation_schema(cls) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "verdict": {"type": "string", "enum": [str(v) for v in Verdict]},
+                "category": {
+                    "type": "string",
+                    "enum": [str(c) for c in ThreatCategory],
+                },
+                "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                "reasoning": {"type": "string"},
+                "remediation": {"type": "string"},
+            },
+            "required": [
+                "verdict",
+                "category",
+                "confidence",
+                "reasoning",
+                "remediation",
+            ],
+        }
+
+    def __init__(
+        self,
+        prompts: Prompts,
+        model: str = DEFAULT_JUDGE_MODEL,
+        temperature: float = 0.0,
+        max_tokens: int = 1024,
+        client: Optional[CompletionClient] = None,
+    ):
+        self.model = model
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self._system = prompts.investigator_system
+        self._user_template = Template(prompts.investigator_user_template)
+        self._client = client or build_completion_client()
+        self._schema = self._investigation_schema()
+
+    @property
+    def auth_mode(self) -> str:
+        return type(self._client).__name__
+
+    def investigate(self, collector: str, finding: dict) -> Optional[dict]:
+        """Return a fresh judgment
+        ``{verdict, category, confidence, reasoning, remediation}`` (verdict and
+        category as enums) or None on failure. Never raises."""
+        user = self._user_template.safe_substitute(
+            collector=collector,
+            finding=json.dumps(finding, ensure_ascii=False, default=str),
+        )
+        try:
+            parsed = self._client.complete_structured(
+                model=self.model,
+                system=self._system,
+                user=user,
+                max_tokens=self.max_tokens,
+                temperature=self.temperature,
+                schema=self._schema,
+                schema_name=self.SCHEMA_NAME,
+            )
+        except Exception as exc:
+            LOG.warning(
+                "investigator failed error=%s msg=%s",
+                type(exc).__name__,
+                str(exc)[:200],
+            )
+            return None
+        try:
+            confidence = float(parsed.get("confidence") or 0.0)
+        except (TypeError, ValueError):
+            confidence = 0.0
+        return {
+            "verdict": Coerce.enum(
+                str(parsed.get("verdict") or "").strip().lower(),
+                Verdict,
+                Verdict.UNKNOWN,
+            ),
+            "category": Coerce.enum(
+                str(parsed.get("category") or "").strip().lower(),
+                ThreatCategory,
+                ThreatCategory.NONE,
+            ),
+            "confidence": max(0.0, min(1.0, confidence)),
+            "reasoning": str(parsed.get("reasoning") or "")[:500],
+            "remediation": str(parsed.get("remediation") or "")[:2000],
+        }
+
+
+def build_investigator(
+    args, prompts: Prompts
+) -> "Optional[UnknownFindingInvestigator]":
+    """Build the investigator when enabled and credentials exist. Returns None
+    (investigation disabled) otherwise — the same credential rule as the
+    judge, since it needs an LLM client."""
+    if getattr(args, "no_investigate", False):
+        return None
+    if not prompts.investigator_system:
+        LOG.warning("investigator prompt missing from prompts file; disabled")
+        return None
+    has_oauth = bool(os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"))
+    has_api_key = bool(
+        os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    )
+    if not has_oauth and not has_api_key:
+        return None
+    if not has_oauth and not HAS_LITELLM:
+        return None
+    try:
+        investigator = UnknownFindingInvestigator(
+            prompts=prompts, model=args.judge_model
+        )
+    except RuntimeError as exc:
+        LOG.warning("UnknownFindingInvestigator unavailable (%s); disabled", exc)
+        return None
+    LOG.info(
+        "investigator auth_mode=%s model=%s",
+        investigator.auth_mode,
+        investigator.model,
+    )
+    return investigator

--- a/src/avai/host_monitor/main.py
+++ b/src/avai/host_monitor/main.py
@@ -24,13 +24,16 @@ from .constants import (
     DEFAULT_PROMPTS_PATH,
     LOG,
 )
+from .coverage import build_coverage_assessor
 from .hosts import HostFactory
+from .investigator import build_investigator
 from .judge import build_judge
 from .models import Base
 from .narrator import build_narrator
 from .prompts import Prompts
 from .runner import Runner
 from .sink import Sink
+from .verifier import build_verifier
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -80,7 +83,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--prompts-file",
         default=str(DEFAULT_PROMPTS_PATH),
-        help=f"Path to prompts TOML " f"(default: {DEFAULT_PROMPTS_PATH})",
+        help=f"Path to prompts TOML (default: {DEFAULT_PROMPTS_PATH})",
     )
     parser.add_argument(
         "--baseline-runs",
@@ -103,6 +106,27 @@ def _build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_NARRATIVE_MODEL,
         help=f"Model id for the incident narrator (default: "
         f"{DEFAULT_NARRATIVE_MODEL}, i.e. the judge model).",
+    )
+    parser.add_argument(
+        "--no-coverage",
+        action="store_true",
+        help="Disable the YARA ruleset-coverage assessment (the second-stage "
+        "LLM that judges whether the loaded rules cover this host's threat "
+        "surface). Uses --narrative-model.",
+    )
+    parser.add_argument(
+        "--no-verify",
+        action="store_true",
+        help="Disable the malicious-verdict verifier (the skeptic second pass "
+        "that downgrades unsupported malicious verdicts to suspicious). Uses "
+        "--judge-model.",
+    )
+    parser.add_argument(
+        "--no-investigate",
+        action="store_true",
+        help="Disable the unknown-finding investigator (the deep second pass "
+        "that re-judges unknown verdicts with full-history context). Uses "
+        "--judge-model.",
     )
     parser.add_argument(
         "--no-streaming",
@@ -170,13 +194,20 @@ def main() -> int:
 
     judge = build_judge(args, prompts)
     narrator = build_narrator(args, prompts)
+    coverage = build_coverage_assessor(args, prompts)
+    verifier = build_verifier(args, prompts)
+    investigator = build_investigator(args, prompts)
     LOG.info(
-        "starting host_monitor db=%s interval=%ds lookback=%dm judge=%s narrator=%s",
+        "starting host_monitor db=%s interval=%ds lookback=%dm judge=%s "
+        "narrator=%s coverage=%s verify=%s investigate=%s",
         db_path,
         args.interval,
         args.lookback_min,
         type(judge).__name__,
         type(narrator).__name__ if narrator else "off",
+        type(coverage).__name__ if coverage else "off",
+        type(verifier).__name__ if verifier else "off",
+        type(investigator).__name__ if investigator else "off",
     )
 
     # check_same_thread=False allows the connection pool to hand
@@ -216,6 +247,9 @@ def main() -> int:
             enrichment_chain=enrichment_chain,
             baseline_min_runs=max(1, args.baseline_runs),
             narrator=narrator,
+            coverage=coverage,
+            verifier=verifier,
+            investigator=investigator,
         )
         runner.setup()
         # Seed the cooperative control row with this run's settings so the

--- a/src/avai/host_monitor/models.py
+++ b/src/avai/host_monitor/models.py
@@ -110,6 +110,31 @@ class RiskScoreRow(Base):
     explanation: Mapped[Optional[str]]
 
 
+class YaraCoverageRow(Base):
+    """One LLM assessment of how well the loaded YARA ruleset covers THIS
+    host's threat surface (the ruleset's category mix weighed against the
+    host's platform + inventory). The dashboard shows the most recent row.
+    ``ruleset_fingerprint`` is the signature of the ruleset the assessment
+    was made against — compared cycle-to-cycle so we only regenerate when
+    the loaded ruleset actually changes (it's static within a process)."""
+
+    __tablename__ = "yara_coverage"
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    created_at: Mapped[str] = mapped_column(index=True)
+    run_id: Mapped[Optional[str]]
+    model: Mapped[str]
+    # well_covered | partial | thin
+    posture: Mapped[str]
+    headline: Mapped[str]
+    summary: Mapped[Optional[str]]
+    # JSON arrays the dashboard renders:
+    #   gaps_json:            [{"area","detail"}]
+    #   recommendations_json: [{"action","detail"}]
+    gaps_json: Mapped[Optional[str]]
+    recommendations_json: Mapped[Optional[str]]
+    ruleset_fingerprint: Mapped[Optional[str]]
+
+
 class StreamingSession(Base):
     """One row per StreamingWorker lifetime. Rows produced by a streaming
     collector reference this via ``run_id`` (same column as snapshot
@@ -123,6 +148,28 @@ class StreamingSession(Base):
     started_at: Mapped[str]
     finished_at: Mapped[Optional[str]]
     row_count: Mapped[int] = mapped_column(default=0)
+
+
+class FeedbackRow(Base):
+    """One operator correction on a finding, keyed like :class:`Judgement`
+    (content_hash + collector). The read-only dashboard writes these; the
+    monitor (a) applies the correction to the existing verdict and (b) feeds
+    recent corrections back to the judge as host-specific ground-truth so
+    closely-matching future artifacts are classified the same way.
+
+    ``artifact`` is the human display string captured at click time (the
+    dashboard has it; the monitor would otherwise have to re-derive it).
+    ``applied`` flips to 1 once the monitor has corrected the verdict — the
+    row is kept regardless, since the future-guidance use reads all rows."""
+
+    __tablename__ = "feedback"
+    content_hash: Mapped[str] = mapped_column(primary_key=True)
+    collector: Mapped[str] = mapped_column(primary_key=True)
+    label: Mapped[str]  # FeedbackLabel
+    note: Mapped[Optional[str]]
+    artifact: Mapped[Optional[str]]
+    created_at: Mapped[str] = mapped_column(index=True)
+    applied: Mapped[int] = mapped_column(default=0)
 
 
 class ControlState(Base):
@@ -402,6 +449,12 @@ class FileScanRow(_RowBase):
     namespace: Mapped[Optional[str]]
     tags_json: Mapped[Optional[str]]
     meta_json: Mapped[Optional[str]]
+    # Redacted, bounded sample of the bytes that actually matched the rule
+    # ([{id, offset, text|hex, truncated}]). Lets the judge tell a
+    # substantive hit (a real C2 URL / mutex) from a generic substring (a
+    # likely false positive). Not part of judge_fields, so it never changes
+    # the content_hash.
+    strings_json: Mapped[Optional[str]]
     size: Mapped[Optional[int]]
     mtime: Mapped[Optional[float]]
     scan_source: Mapped[Optional[str]]

--- a/src/avai/host_monitor/prompts.py
+++ b/src/avai/host_monitor/prompts.py
@@ -1,4 +1,5 @@
 """Prompt-file loading (per-collector judge hints)."""
+
 from __future__ import annotations
 
 import tomllib
@@ -23,6 +24,12 @@ class Prompts:
     collector_hints: dict[str, str] = field(default_factory=dict)
     narrator_system: str = ""
     narrator_user_template: str = ""
+    coverage_system: str = ""
+    coverage_user_template: str = ""
+    verifier_system: str = ""
+    verifier_user_template: str = ""
+    investigator_system: str = ""
+    investigator_user_template: str = ""
 
     @classmethod
     def load(cls, path: Path) -> "Prompts":
@@ -38,12 +45,25 @@ class Prompts:
         narrator_system = Template(narrator.get("system", "")).safe_substitute(
             categories=", ".join(str(c) for c in ThreatCategory),
         )
+        coverage = data.get("yara_coverage") or {}
+        verifier = data.get("verifier") or {}
+        investigator = data.get("investigator") or {}
+        investigator_system = Template(investigator.get("system", "")).safe_substitute(
+            verdicts=" | ".join(str(v) for v in Verdict),
+            categories=", ".join(str(c) for c in ThreatCategory),
+        )
         return cls(
             system=system,
             user_template=judge.get("user_template", ""),
             collector_hints=dict(data.get("collector_hints") or {}),
             narrator_system=narrator_system,
             narrator_user_template=narrator.get("user_template", ""),
+            coverage_system=coverage.get("system", ""),
+            coverage_user_template=coverage.get("user_template", ""),
+            verifier_system=verifier.get("system", ""),
+            verifier_user_template=verifier.get("user_template", ""),
+            investigator_system=investigator_system,
+            investigator_user_template=investigator.get("user_template", ""),
         )
 
     def hint_for(self, collector_name: str) -> str:

--- a/src/avai/host_monitor/runner.py
+++ b/src/avai/host_monitor/runner.py
@@ -2,22 +2,51 @@
 
 from __future__ import annotations
 
+import bisect
 import json
 import os
+import platform
 import socket
 import threading
 import time
+from dataclasses import replace
 from typing import Optional
 
 from .collectors import Collector, SnapshotCollector, StreamingCollector
-from .constants import _CORRELATED_COLLECTOR, DEFAULT_BASELINE_MIN_RUNS, LOG
-from .enums import Verdict
+from .constants import (
+    _CORRELATED_COLLECTOR,
+    _FILE_SCAN_COLLECTOR,
+    _LAUNCH_ITEM_COLLECTOR,
+    DEFAULT_BASELINE_MIN_RUNS,
+    LOG,
+)
+from .enums import FeedbackLabel, Verdict
 from .judge import Judge, NullJudge
 from .narrator import IncidentNarrator
 from .risk import compute_risk_score
 from .runtime import Clock, Digest
 from .sink import Sink
 from .streaming import StreamingWorker
+
+# Minimum presence window (runs since first seen) before an artifact that
+# misses runs is called "intermittent" — below this it's just freshly seen.
+_MIN_DRIFT_WINDOW = 3
+
+# Bound second-pass LLM work per collector per cycle so a pathological batch
+# can't fan out into unbounded verify / investigate calls.
+_MAX_VERIFY_PER_COLLECTOR = 10
+_MAX_INVESTIGATE_PER_COLLECTOR = 10
+
+# How many of the host's other non-benign findings to hand the investigator
+# as situational context.
+_HOST_CONTEXT_LIMIT = 15
+
+# How an operator-feedback label reads in the ground-truth block fed to the
+# judge. Keyed by the raw stored label.
+_FEEDBACK_PHRASE = {
+    FeedbackLabel.FALSE_POSITIVE.value: "a FALSE POSITIVE (benign)",
+    FeedbackLabel.CONFIRMED.value: "CONFIRMED malicious",
+}
 
 
 class Runner:
@@ -37,6 +66,9 @@ class Runner:
         enrichment_chain=None,
         baseline_min_runs: int = DEFAULT_BASELINE_MIN_RUNS,
         narrator: "Optional[IncidentNarrator]" = None,
+        coverage=None,
+        verifier=None,
+        investigator=None,
     ):
         self.sink = sink
         self.snapshot_collectors = snapshot_collectors
@@ -47,6 +79,12 @@ class Runner:
         self.baseline_min_runs = baseline_min_runs
         # Optional second-stage incident-digest LLM. None ⇒ disabled.
         self.narrator = narrator
+        # Optional second-stage YARA ruleset-coverage assessor. None ⇒ disabled.
+        self.coverage = coverage
+        # Optional skeptic that re-checks malicious verdicts. None ⇒ disabled.
+        self.verifier = verifier
+        # Optional deep re-judge for unknown findings. None ⇒ disabled.
+        self.investigator = investigator
         self._streaming_workers: list[StreamingWorker] = []
         self.shutdown_event = threading.Event()
         # Optional threat-intel enrichment between collection and judging.
@@ -110,10 +148,7 @@ class Runner:
     def _dispatch_command(self, cmd: Optional[str]) -> str:
         if cmd == "prune":
             stats = self.sink.prune_to_size(self.max_db_bytes or 0)
-            return (
-                f"pruned runs={stats['runs_pruned']} "
-                f"events={stats['events_pruned']}"
-            )
+            return f"pruned runs={stats['runs_pruned']} events={stats['events_pruned']}"
         if cmd == "clear":
             return f"cleared {self.sink.clear_data()} rows"
         if cmd == "rejudge":
@@ -148,6 +183,9 @@ class Runner:
         # Refresh the control cache so --once and the daemon loop both honour
         # disabled-collector / judge / enrich toggles set from the dashboard.
         self._refresh_control()
+        # Apply any operator corrections before judging so this cycle's
+        # narrative / risk reflect the fixed verdicts.
+        self._apply_feedback()
         run_id, started = self.sink.start_run(socket.gethostname(), self.lookback_min)
         # Snapshot the host's baseline state once: it can't change mid-cycle
         # (the current run isn't completed yet), and every collector shares
@@ -192,6 +230,9 @@ class Runner:
             self._generate_risk_score(run_id, started)
             # Persist the file scanner's ruleset summary for the dashboard.
             self._write_yara_status()
+            # Assess whether the loaded ruleset covers this host (LLM, opt-in).
+            if self.coverage is not None:
+                self._generate_coverage(run_id, started)
         self.sink.end_run(ok, failed)
 
         # Rotation: keep the DB under the configured size cap by pruning
@@ -250,37 +291,122 @@ class Runner:
             return
         cutoff = host_baseline["cutoff_at"]
         established = host_baseline["established"]
+        # Run timeline (incl. the in-progress run) to size each artifact's
+        # presence window — how many runs have happened since it first
+        # appeared. Fetched once; an artifact present in fewer runs than its
+        # window has come and gone (intermittent), a sharper drift signal than
+        # the novelty bit alone.
+        try:
+            timeline = self.sink.run_started_ats()
+        except Exception as exc:
+            LOG.warning("baseline: run timeline fetch failed: %s", exc)
+            timeline = []
         for entry in unjudged:
             seen = fs_map.get(entry.get("content_hash"))
             if seen is None:
                 continue
             first_seen, times_seen = seen
             novel = bool(established and cutoff is not None and first_seen > cutoff)
+            window = (
+                len(timeline) - bisect.bisect_left(timeline, first_seen)
+                if timeline
+                else 0
+            )
+            # Needs at least a few runs of window to distinguish flapping from
+            # a freshly-seen artifact.
+            intermittent = window >= _MIN_DRIFT_WINDOW and times_seen < window
             entry["baseline"] = {
                 "first_seen": first_seen,
                 "times_seen": times_seen,
                 "host_runs": host_baseline["total_runs"],
                 "baseline_established": established,
                 "novel": novel,
+                "intermittent": intermittent,
             }
 
     def _attach_correlation(
         self, c: Collector, unjudged: list[dict], rows: list[dict], run_id: str
     ) -> None:
-        """Attach a ``related`` object to each ``processes`` entry in-place:
-        the process's listening ports, outbound flows, remote connections,
-        DNS queries and exec lineage, correlated by PID (DNS by process
-        name). This lets the judge score the process *with its behaviour*
-        instead of in isolation — a novel binary that is also beaconing to
-        a flagged IP is a far stronger signal than either row alone.
+        """Attach a ``related`` object — the artifact's listening ports,
+        outbound flows, remote connections, DNS queries and exec lineage,
+        correlated by PID (DNS by process name) — so the judge scores it
+        *with its behaviour* instead of in isolation. A novel binary (or a
+        launch item) that is also beaconing to a flagged IP is a far stronger
+        signal than either row alone.
 
-        Only the ``processes`` collector is correlated; flows/DNS keep their
-        own independent verdicts. The unjudged projection has no PID (its
-        content_hash is over name/exe/cmdline/username), so we map
-        content_hash → PIDs/names via the full ``rows``, exactly as
-        ``_enrich_entries`` maps evidence."""
-        if c.name != _CORRELATED_COLLECTOR or not unjudged:
+        Correlated collectors:
+        - ``processes``: PID/name come straight from the collector's rows.
+        - ``launch_items``: the unjudged entry has no PID, so we resolve each
+          item's ``program`` to the live process(es) running it, then use
+          those PIDs.
+        Other collectors keep their own independent verdicts."""
+        if not unjudged or c.name not in (
+            _CORRELATED_COLLECTOR,
+            _LAUNCH_ITEM_COLLECTOR,
+        ):
             return
+        try:
+            since = self.sink.prior_run_started_at(run_id)
+        except Exception as exc:
+            LOG.warning("correlation: prior_run(%s) failed: %s", c.name, exc)
+            return
+        pids_by_hash, names_by_hash = self._behavior_pid_map(c, rows, since)
+        all_pids = sorted({p for s in pids_by_hash.values() for p in s})
+        all_names = sorted({n for s in names_by_hash.values() for n in s})
+        if not all_pids and not all_names:
+            return
+        try:
+            ctx = self.sink.correlation_context(all_pids, all_names, since)
+        except Exception as exc:
+            LOG.warning("correlation: context(%s) failed: %s", c.name, exc)
+            return
+        for entry in unjudged:
+            h = entry.get("content_hash")
+            related = self._related_from_ctx(
+                ctx, pids_by_hash.get(h, set()), names_by_hash.get(h, set())
+            )
+            if related:
+                entry["related"] = related
+
+    def _behavior_pid_map(
+        self, c: Collector, rows: list[dict], since: Optional[str]
+    ) -> tuple[dict, dict]:
+        """content_hash → (PIDs, names) for a correlatable collector, or two
+        empty maps for anything else. Dispatches on the collector instead of
+        branching at each call site."""
+        if c.name == _CORRELATED_COLLECTOR:
+            return self._process_pid_map(rows)
+        if c.name == _LAUNCH_ITEM_COLLECTOR:
+            return self._launch_item_pid_map(rows, since)
+        return {}, {}
+
+    @staticmethod
+    def _related_from_ctx(ctx: dict, pids: set, names: set) -> dict:
+        """Assemble the ``related`` behaviour object for one artifact from a
+        correlation context, bounded per kind. Shared by per-cycle correlation
+        and the investigator's full-history bundle."""
+        related: dict = {}
+        ports = [p for pid in pids for p in ctx["ports"].get(pid, [])]
+        flows = [f for pid in pids for f in ctx["flows"].get(pid, [])]
+        conns = [cc for pid in pids for cc in ctx["conns"].get(pid, [])]
+        dns = [d for n in names for d in ctx["dns"].get(n, [])]
+        execs = [ctx["exec"][pid] for pid in pids if pid in ctx["exec"]]
+        if ports:
+            related["listening_ports"] = ports[:10]
+        if flows:
+            related["outbound_flows"] = flows[:10]
+        if conns:
+            related["remote_connections"] = conns[:10]
+        if dns:
+            related["dns_queries"] = dns[:15]
+        if execs:
+            related["exec_lineage"] = execs[0]
+        return related
+
+    @staticmethod
+    def _process_pid_map(rows: list[dict]) -> tuple[dict, dict]:
+        """content_hash → (PIDs, names) from the processes rows' own
+        pid/name fields."""
         pids_by_hash: dict[str, set] = {}
         names_by_hash: dict[str, set] = {}
         for r in rows:
@@ -291,36 +417,77 @@ class Runner:
                 pids_by_hash.setdefault(h, set()).add(r["pid"])
             if r.get("name"):
                 names_by_hash.setdefault(h, set()).add(r["name"])
-        all_pids = sorted({p for s in pids_by_hash.values() for p in s})
-        all_names = sorted({n for s in names_by_hash.values() for n in s})
+        return pids_by_hash, names_by_hash
+
+    def _launch_item_pid_map(
+        self, rows: list[dict], since: Optional[str]
+    ) -> tuple[dict, dict]:
+        """content_hash → (PIDs, names) for launch items: resolve each item's
+        ``program`` to the live process(es) running it (via the process
+        snapshot at/after ``since``), so a persistence entry is judged with
+        the behaviour of the process it spawns. names carry the program
+        basename so DNS-by-process-name correlation still applies."""
+        programs_by_hash: dict[str, set] = {}
+        for r in rows:
+            h = r.get("content_hash")
+            prog = r.get("program")
+            if isinstance(h, str) and h and isinstance(prog, str) and prog:
+                programs_by_hash.setdefault(h, set()).add(prog)
+        all_programs = sorted({p for s in programs_by_hash.values() for p in s})
         try:
-            since = self.sink.prior_run_started_at(run_id)
-            ctx = self.sink.correlation_context(all_pids, all_names, since)
+            pids_for_exe = self.sink.pids_by_executable(all_programs, since)
         except Exception as exc:
-            LOG.warning("correlation: context(%s) failed: %s", c.name, exc)
+            LOG.warning("correlation: pids_by_executable failed: %s", exc)
+            pids_for_exe = {}
+        pids_by_hash: dict[str, set] = {}
+        names_by_hash: dict[str, set] = {}
+        for h, progs in programs_by_hash.items():
+            for prog in progs:
+                for pid in pids_for_exe.get(prog, ()):
+                    pids_by_hash.setdefault(h, set()).add(pid)
+                names_by_hash.setdefault(h, set()).add(prog.rsplit("/", 1)[-1])
+        return pids_by_hash, names_by_hash
+
+    def _attach_yara_context(
+        self, c: Collector, unjudged: list[dict], rows: list[dict]
+    ) -> None:
+        """Attach the matched rule's own metadata and a redacted sample of
+        the matched bytes to each ``file_scan`` entry in-place, so the judge
+        can triage false positives and attribute the rule instead of seeing
+        only the rule name + tags.
+
+        Both fields live on the collector ``rows`` but not in ``judge_fields``
+        (so they don't affect the content_hash); we map content_hash → row
+        exactly as ``_enrich_entries`` maps evidence, then surface ``meta_json``
+        as ``rule_meta`` and ``strings_json`` as ``matched_strings``."""
+        if c.name != _FILE_SCAN_COLLECTOR or not unjudged:
             return
+        rows_by_hash: dict[str, dict] = {}
+        for r in rows:
+            h = r.get("content_hash")
+            if isinstance(h, str) and h and h not in rows_by_hash:
+                rows_by_hash[h] = r
         for entry in unjudged:
-            h = entry.get("content_hash")
-            pids = pids_by_hash.get(h, set())
-            names = names_by_hash.get(h, set())
-            related: dict = {}
-            ports = [p for pid in pids for p in ctx["ports"].get(pid, [])]
-            flows = [f for pid in pids for f in ctx["flows"].get(pid, [])]
-            conns = [cc for pid in pids for cc in ctx["conns"].get(pid, [])]
-            dns = [d for n in names for d in ctx["dns"].get(n, [])]
-            execs = [ctx["exec"][pid] for pid in pids if pid in ctx["exec"]]
-            if ports:
-                related["listening_ports"] = ports[:10]
-            if flows:
-                related["outbound_flows"] = flows[:10]
-            if conns:
-                related["remote_connections"] = conns[:10]
-            if dns:
-                related["dns_queries"] = dns[:15]
-            if execs:
-                related["exec_lineage"] = execs[0]
-            if related:
-                entry["related"] = related
+            row = rows_by_hash.get(entry.get("content_hash"))
+            if row is None:
+                continue
+            meta = self._loads_or_none(row.get("meta_json"))
+            if isinstance(meta, dict) and meta:
+                entry["rule_meta"] = meta
+            strings = self._loads_or_none(row.get("strings_json"))
+            if isinstance(strings, list) and strings:
+                entry["matched_strings"] = strings
+
+    @staticmethod
+    def _loads_or_none(raw):
+        """Parse a JSON column value, returning None on absence/garbage so a
+        malformed row can't break the judge wiring."""
+        if not isinstance(raw, str) or not raw:
+            return None
+        try:
+            return json.loads(raw)
+        except (ValueError, TypeError):
+            return None
 
     @staticmethod
     def _judgment_context(unjudged: list[dict]) -> dict:
@@ -341,6 +508,163 @@ class Runner:
             if parts:
                 ctx[h] = parts
         return ctx
+
+    def _verify_judgments(
+        self, collector: str, judgments: list, unjudged: list[dict]
+    ) -> list:
+        """Re-check each ``malicious`` verdict with the independent skeptic; a
+        refuted verdict is downgraded to ``suspicious`` (still flagged for
+        review, not asserted as an active threat). No-op without a verifier;
+        bounded per collector so a batch of malicious can't fan out."""
+        if self.verifier is None or not judgments:
+            return judgments
+        by_hash = {e.get("content_hash"): e for e in unjudged if e.get("content_hash")}
+        out: list = []
+        checked = 0
+        for j in judgments:
+            if j.verdict != Verdict.MALICIOUS or checked >= _MAX_VERIFY_PER_COLLECTOR:
+                out.append(j)
+                continue
+            checked += 1
+            entry = by_hash.get(j.content_hash, {})
+            finding = {
+                "collector": collector,
+                "verdict": str(j.verdict),
+                "category": str(j.category),
+                "reasoning": j.reasoning,
+                **{k: v for k, v in entry.items() if k != "content_hash"},
+            }
+            result = self.verifier.verify(finding)
+            if result and result["refuted"]:
+                out.append(
+                    replace(
+                        j,
+                        verdict=Verdict.SUSPICIOUS,
+                        reasoning=(
+                            f"[verifier downgraded malicious→suspicious] "
+                            f"{result['reasoning']} · original: {j.reasoning}"
+                        )[:500],
+                    )
+                )
+                LOG.info(
+                    "verifier downgraded collector=%s reason=%s",
+                    collector,
+                    result["reasoning"][:120],
+                )
+            else:
+                out.append(j)
+        return out
+
+    def _apply_feedback(self) -> None:
+        """Pin operator corrections onto their findings' verdicts. Best-effort
+        — a feedback failure must not stop the cycle."""
+        try:
+            n = self.sink.apply_feedback()
+        except Exception:
+            LOG.exception("apply_feedback failed")
+            return
+        if n:
+            LOG.info("applied %d operator feedback correction(s)", n)
+
+    def _judge_hints(self, collector_name: str, base_hints: str) -> str:
+        """Append this host's recent operator feedback for the collector to
+        the static hints as ground-truth examples, so the judge classifies
+        matching artifacts the same way. Returns the base hints unchanged when
+        there's no feedback."""
+        try:
+            examples = self.sink.feedback_examples(collector_name)
+        except Exception as exc:
+            LOG.warning("feedback_examples(%s) failed: %s", collector_name, exc)
+            return base_hints
+        if not examples:
+            return base_hints
+        lines = []
+        for e in examples:
+            artifact = (e.get("artifact") or "").strip() or "(unnamed artifact)"
+            phrase = _FEEDBACK_PHRASE.get(e.get("label"), e.get("label"))
+            note = f" note: {e['note']}" if e.get("note") else ""
+            lines.append(f'- "{artifact}" was marked {phrase} by the operator.{note}')
+        return base_hints + (
+            "\nOperator feedback for this host (ground truth — apply the same "
+            "judgement to these and closely-matching artifacts):\n" + "\n".join(lines)
+        )
+
+    def _investigate_unknowns(
+        self, c: Collector, judgments: list, unjudged: list[dict], rows: list[dict]
+    ) -> list:
+        """Re-judge each ``unknown`` verdict with a richer, deliberately
+        gathered bundle: the artifact's FULL-HISTORY correlated behaviour (not
+        just the previous cycle) plus the host's other non-benign findings.
+        A committed verdict replaces the unknown. No-op without an
+        investigator; bounded per collector. Snapshot collectors only — their
+        ``rows`` are needed to resolve behaviour."""
+        if self.investigator is None or not judgments:
+            return judgments
+        by_hash = {e.get("content_hash"): e for e in unjudged if e.get("content_hash")}
+        # Full history: since=None drops the previous-cycle time bound.
+        pids_by_hash, names_by_hash = self._behavior_pid_map(c, rows, None)
+        all_pids = sorted({p for s in pids_by_hash.values() for p in s})
+        all_names = sorted({n for s in names_by_hash.values() for n in s})
+        ctx = None
+        host_context: list = []
+        out: list = []
+        investigated = 0
+        for j in judgments:
+            stop = investigated >= _MAX_INVESTIGATE_PER_COLLECTOR
+            if j.verdict != Verdict.UNKNOWN or stop:
+                out.append(j)
+                continue
+            investigated += 1
+            if ctx is None:  # gather the shared context once, on first unknown
+                ctx = self._full_history_context(all_pids, all_names)
+                host_context = self._host_context()
+            entry = by_hash.get(j.content_hash, {})
+            finding = {k: v for k, v in entry.items() if k != "content_hash"}
+            related_full = self._related_from_ctx(
+                ctx,
+                pids_by_hash.get(j.content_hash, set()),
+                names_by_hash.get(j.content_hash, set()),
+            )
+            if related_full:
+                finding["related_full"] = related_full
+            others = [h for h in host_context if h["content_hash"] != j.content_hash]
+            if others:
+                finding["host_context"] = others
+            result = self.investigator.investigate(c.name, finding)
+            if result and result["verdict"] != Verdict.UNKNOWN:
+                out.append(
+                    replace(
+                        j,
+                        verdict=result["verdict"],
+                        category=result["category"],
+                        confidence=result["confidence"],
+                        reasoning=f"[investigated] {result['reasoning']}"[:500],
+                        remediation=result["remediation"],
+                    )
+                )
+                LOG.info(
+                    "investigator resolved collector=%s unknown→%s",
+                    c.name,
+                    str(result["verdict"]),
+                )
+            else:
+                out.append(j)
+        return out
+
+    def _full_history_context(self, pids: list, names: list) -> dict:
+        """Correlation context over all retained history (since=None)."""
+        try:
+            return self.sink.correlation_context(pids, names, None)
+        except Exception as exc:
+            LOG.warning("investigate: full-history context failed: %s", exc)
+            return {"ports": {}, "flows": {}, "conns": {}, "dns": {}, "exec": {}}
+
+    def _host_context(self) -> list:
+        try:
+            return self.sink.recent_nonbenign(_HOST_CONTEXT_LIMIT)
+        except Exception as exc:
+            LOG.warning("investigate: host context failed: %s", exc)
+            return []
 
     def _run_collector(
         self, c: SnapshotCollector, run_id: str, started: str, host_baseline: dict
@@ -365,7 +689,11 @@ class Runner:
                 enriched_indicators = self._enrich_entries(c, unjudged, rows)
                 self._annotate_baseline(c, unjudged, host_baseline)
                 self._attach_correlation(c, unjudged, rows, run_id)
-                judgments = self.judge.judge(c.name, c.judge_hints, unjudged)
+                self._attach_yara_context(c, unjudged, rows)
+                hints = self._judge_hints(c.name, c.judge_hints)
+                judgments = self.judge.judge(c.name, hints, unjudged)
+                judgments = self._verify_judgments(c.name, judgments, unjudged)
+                judgments = self._investigate_unknowns(c, judgments, unjudged, rows)
                 self.sink.write_judgments(
                     judgments, context=self._judgment_context(unjudged)
                 )
@@ -460,7 +788,9 @@ class Runner:
                 continue
             self._annotate_baseline(c, unjudged, host_baseline)
             try:
-                judgments = self.judge.judge(c.name, c.judge_hints, unjudged)
+                hints = self._judge_hints(c.name, c.judge_hints)
+                judgments = self.judge.judge(c.name, hints, unjudged)
+                judgments = self._verify_judgments(c.name, judgments, unjudged)
                 self.sink.write_judgments(
                     judgments, context=self._judgment_context(unjudged)
                 )
@@ -572,6 +902,71 @@ class Runner:
             self.sink.write_yara_rules(stats.get("inventory") or [])
         except Exception as exc:  # noqa: BLE001
             LOG.warning("yara_status: write failed: %s", exc)
+
+    def _generate_coverage(self, run_id: str, started: str) -> None:
+        """Assess whether the loaded YARA ruleset covers this host's threat
+        surface and store the result — but only when the ruleset has changed
+        since the last assessment, so we don't re-spend tokens on a ruleset
+        that's static within a process. Never raises (best-effort)."""
+        try:
+            ruleset = self.sink.read_yara_status()
+        except Exception as exc:
+            LOG.warning("coverage: read_yara_status failed: %s", exc)
+            return
+        if not ruleset or not ruleset.get("rules_loaded"):
+            return
+        fingerprint = self._ruleset_fingerprint(ruleset)
+        try:
+            if self.sink.latest_yara_coverage_fingerprint() == fingerprint:
+                return  # ruleset unchanged since the last assessment
+        except Exception:
+            pass  # comparison is an optimisation; fall through and assess
+        try:
+            host = self.sink.coverage_profile(run_id)
+        except Exception as exc:
+            LOG.warning("coverage: profile failed: %s", exc)
+            return
+        host["platform"] = platform.system()
+        host["hostname"] = socket.gethostname()
+        result = self.coverage.assess(ruleset, host)
+        if not result:
+            return
+        try:
+            self.sink.write_yara_coverage(
+                {
+                    "created_at": Clock().now_iso(),
+                    "run_id": run_id,
+                    "model": self.coverage.model,
+                    "posture": result["posture"],
+                    "headline": result["headline"],
+                    "summary": result["summary"],
+                    "gaps_json": json.dumps(result["gaps"]),
+                    "recommendations_json": json.dumps(result["recommendations"]),
+                    "ruleset_fingerprint": fingerprint,
+                }
+            )
+            LOG.info(
+                "coverage posture=%s gaps=%d recommendations=%d",
+                result["posture"],
+                len(result["gaps"]),
+                len(result["recommendations"]),
+            )
+        except Exception as exc:
+            LOG.warning("coverage: write failed: %s", exc)
+
+    @staticmethod
+    def _ruleset_fingerprint(ruleset: dict) -> str:
+        """Stable signature of the loaded ruleset — its rule count, per-source
+        counts, and category set. Changes only when the rules actually change,
+        gating regeneration of the (token-costing) coverage assessment."""
+        return json.dumps(
+            {
+                "rules": ruleset.get("rules_loaded"),
+                "sources": sorted((ruleset.get("sources") or {}).items()),
+                "cats": sorted((ruleset.get("by_category") or {}).keys()),
+            },
+            sort_keys=True,
+        )
 
     @staticmethod
     def _risk_explanation(result: dict, prev) -> str:

--- a/src/avai/host_monitor/sink.py
+++ b/src/avai/host_monitor/sink.py
@@ -25,25 +25,33 @@ from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
 
 from .constants import LOG
-from .enums import Verdict
+from .enums import FeedbackLabel, Verdict
 from .judge import Judgment
 from .models import (
     AuthEventRow,
     Base,
+    BrowserExtensionRow,
     CollectionRun,
     CollectorErrorRow,
     ControlState,
     DnsQueryRow,
+    FeedbackRow,
     IncidentNarrativeRow,
+    InstalledAppRow,
     Judgement,
+    KernelExtensionRow,
+    LaunchItemRow,
     ListeningPortRow,
     NetworkConnectionRow,
     NetworkFlowRow,
     PrivilegeConfigRow,
     ProcessExecRow,
+    ProcessRow,
     RiskScoreRow,
     StreamingSession,
+    SystemExtensionRow,
     SystemIntegrityRow,
+    YaraCoverageRow,
     YaraRuleRow,
     YaraStatusRow,
     _RowBase,
@@ -66,6 +74,13 @@ _BUSY_TIMEOUT_MS = 30_000
 # directory itself must be group-writable, not just the db file.
 _DB_DIR_MODE = 0o775  # rwxrwxr-x
 _DB_FILE_MODE = 0o664  # rw-rw-r--
+
+# Operator feedback label → the verdict the monitor pins on the corrected
+# finding. Keyed by the raw string so lookup on a stored label is exact.
+_FEEDBACK_VERDICT = {
+    FeedbackLabel.FALSE_POSITIVE.value: str(Verdict.BENIGN),
+    FeedbackLabel.CONFIRMED.value: str(Verdict.MALICIOUS),
+}
 
 
 class Sink:
@@ -246,6 +261,37 @@ class Sink:
                 .limit(1)
                 .offset(n - 1)
             ).scalar_one_or_none()
+
+    def pids_by_executable(
+        self, exes: list[str], since: Optional[str] = None
+    ) -> dict[str, set]:
+        """Map each executable path to the set of PIDs running it, from the
+        process snapshot at/after ``since``. Resolves a launch item's
+        ``program`` to the live process it spawned, so persistence can be
+        correlated with that process's runtime behaviour."""
+        out: dict[str, set] = {}
+        if not exes:
+            return out
+        stmt = select(ProcessRow.exe, ProcessRow.pid).where(ProcessRow.exe.in_(exes))
+        if since:
+            stmt = stmt.where(ProcessRow.collected_at >= since)
+        with Session(self.engine) as session:
+            for exe, pid in session.execute(stmt).all():
+                if exe and pid is not None:
+                    out.setdefault(exe, set()).add(pid)
+        return out
+
+    def run_started_ats(self) -> list[str]:
+        """Every run's ``started_at`` (including the in-progress run),
+        ascending — the timeline used to size an artifact's presence window
+        for the intermittent/persistent drift signal. ISO strings sort
+        lexicographically, so the caller can bisect directly."""
+        with Session(self.engine) as session:
+            return list(
+                session.execute(
+                    select(CollectionRun.started_at).order_by(CollectionRun.started_at)
+                ).scalars()
+            )
 
     def first_seen_map(
         self, model: type[_RowBase], content_hashes: list[str]
@@ -487,6 +533,86 @@ class Sink:
                 for r in session.execute(stmt).all()
             ]
 
+    # -- operator feedback --------------------------------------------------
+
+    def apply_feedback(self) -> int:
+        """Apply each not-yet-applied operator correction to its finding's
+        verdict (false_positive → benign, confirmed → malicious) and mark it
+        applied. Idempotent; a row whose finding no longer exists updates
+        nothing but is still marked. Returns the number processed."""
+        applied = 0
+        with Session(self.engine) as session:
+            pending = (
+                session.execute(select(FeedbackRow).where(FeedbackRow.applied == 0))
+                .scalars()
+                .all()
+            )
+            for fb in pending:
+                verdict = _FEEDBACK_VERDICT.get(fb.label)
+                if verdict is not None:
+                    reasoning = f"[operator: {fb.label}]"
+                    if fb.note:
+                        reasoning = f"{reasoning} {fb.note}"
+                    session.execute(
+                        update(Judgement)
+                        .where(
+                            Judgement.content_hash == fb.content_hash,
+                            Judgement.collector == fb.collector,
+                        )
+                        .values(
+                            verdict=verdict, confidence=1.0, reasoning=reasoning[:500]
+                        )
+                    )
+                fb.applied = 1
+                applied += 1
+            session.commit()
+        return applied
+
+    def feedback_examples(self, collector: str, limit: int = 10) -> list[dict]:
+        """Recent operator corrections for a collector as
+        ``[{artifact, label, note}]`` — host-specific ground-truth the judge
+        is shown so it classifies matching artifacts the same way."""
+        stmt = (
+            select(FeedbackRow.artifact, FeedbackRow.label, FeedbackRow.note)
+            .where(FeedbackRow.collector == collector)
+            .order_by(FeedbackRow.created_at.desc())
+            .limit(limit)
+        )
+        with Session(self.engine) as session:
+            return [
+                {"artifact": artifact, "label": label, "note": note}
+                for artifact, label, note in session.execute(stmt).all()
+            ]
+
+    def recent_nonbenign(self, limit: int = 15) -> list[dict]:
+        """Most recent non-benign judgments as compact dicts — the host's
+        situational context for the investigator (what else is flagged here)."""
+        stmt = (
+            select(
+                Judgement.content_hash,
+                Judgement.collector,
+                Judgement.verdict,
+                Judgement.category,
+                Judgement.reasoning,
+            )
+            .where(
+                Judgement.verdict.in_([str(Verdict.MALICIOUS), str(Verdict.SUSPICIOUS)])
+            )
+            .order_by(Judgement.created_at.desc())
+            .limit(limit)
+        )
+        with Session(self.engine) as session:
+            return [
+                {
+                    "content_hash": r[0],
+                    "collector": r[1],
+                    "verdict": r[2],
+                    "category": r[3],
+                    "reasoning": r[4],
+                }
+                for r in session.execute(stmt).all()
+            ]
+
     def latest_narrative_finding_hashes(self) -> Optional[str]:
         """``finding_hashes`` of the most recent narrative, or None. Used to
         skip regeneration when the active-finding set is unchanged."""
@@ -591,6 +717,71 @@ class Sink:
             session.execute(delete(YaraRuleRow))
             if inventory:
                 session.execute(sqlite_insert(YaraRuleRow), inventory)
+            session.commit()
+
+    # -- yara coverage assessment -------------------------------------------
+
+    # Inventory tables describing the host's attack surface — the host side
+    # of the coverage assessment (ruleset categories weighed against these).
+    _COVERAGE_INVENTORY = {
+        "processes": ProcessRow,
+        "installed_apps": InstalledAppRow,
+        "launch_items": LaunchItemRow,
+        "browser_extensions": BrowserExtensionRow,
+        "kernel_extensions": KernelExtensionRow,
+        "system_extensions": SystemExtensionRow,
+        "listening_ports": ListeningPortRow,
+    }
+
+    def read_yara_status(self) -> Optional[dict]:
+        """The persisted compiled-ruleset summary (single row), or None. The
+        coverage assessor reads this rather than the collector's in-memory
+        compile stats so it stays decoupled from the scan cycle."""
+        with Session(self.engine) as session:
+            row = session.get(YaraStatusRow, 1)
+        if row is None:
+            return None
+        return {
+            "rules_loaded": row.rules_loaded,
+            "files_loaded": row.files_loaded,
+            "files_skipped": row.files_skipped,
+            "rules_dir": row.rules_dir,
+            "sources": json.loads(row.sources_json or "{}"),
+            "skip_reasons": json.loads(row.skip_reasons_json or "{}"),
+            "by_category": json.loads(row.by_category_json or "{}"),
+        }
+
+    def coverage_profile(self, run_id: str) -> dict:
+        """Per-collector row counts for ``run_id`` over the inventory tables —
+        a compact picture of the host's attack surface for the coverage
+        assessment (e.g. how many apps / launch items / extensions exist)."""
+        counts: dict[str, int] = {}
+        with Session(self.engine) as session:
+            for name, model in self._COVERAGE_INVENTORY.items():
+                counts[name] = int(
+                    session.execute(
+                        select(func.count())
+                        .select_from(model)
+                        .where(model.run_id == run_id)
+                    ).scalar()
+                    or 0
+                )
+        return counts
+
+    def latest_yara_coverage_fingerprint(self) -> Optional[str]:
+        """``ruleset_fingerprint`` of the most recent assessment, or None.
+        Compared to the current ruleset so we skip regeneration when the
+        loaded rules are unchanged."""
+        with Session(self.engine) as session:
+            return session.execute(
+                select(YaraCoverageRow.ruleset_fingerprint)
+                .order_by(YaraCoverageRow.created_at.desc())
+                .limit(1)
+            ).scalar_one_or_none()
+
+    def write_yara_coverage(self, row: dict) -> None:
+        with Session(self.engine) as session:
+            session.add(YaraCoverageRow(**row))
             session.commit()
 
     def database_size_bytes(self) -> int:

--- a/src/avai/host_monitor/verifier.py
+++ b/src/avai/host_monitor/verifier.py
@@ -1,0 +1,112 @@
+"""Second-opinion LLM that adversarially checks ``malicious`` verdicts.
+
+The first-pass judge decides in one shot. A false ``malicious`` is the most
+costly mistake (it cries wolf and gets the tool ignored), so every malicious
+verdict is re-examined by an independent skeptic prompted to *refute* it. A
+refuted verdict is downgraded to ``suspicious`` rather than dropped — still
+worth review, just not asserted as an active threat. Reuses the judge's
+completion client and structured-output path, like the other second stages.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from string import Template
+from typing import Optional
+
+from .constants import DEFAULT_NARRATIVE_MODEL, LOG
+from .judge import HAS_LITELLM, CompletionClient, build_completion_client
+from .prompts import Prompts
+
+
+class MaliciousVerdictVerifier:
+    """Independent skeptic pass over a single ``malicious`` finding."""
+
+    SCHEMA_NAME = "submit_verification"
+
+    @classmethod
+    def _verification_schema(cls) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "refuted": {"type": "boolean"},
+                "reasoning": {"type": "string"},
+            },
+            "required": ["refuted", "reasoning"],
+        }
+
+    def __init__(
+        self,
+        prompts: Prompts,
+        model: str = DEFAULT_NARRATIVE_MODEL,
+        temperature: float = 0.0,
+        max_tokens: int = 512,
+        client: Optional[CompletionClient] = None,
+    ):
+        self.model = model
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self._system = prompts.verifier_system
+        self._user_template = Template(prompts.verifier_user_template)
+        self._client = client or build_completion_client()
+        self._schema = self._verification_schema()
+
+    @property
+    def auth_mode(self) -> str:
+        return type(self._client).__name__
+
+    def verify(self, finding: dict) -> Optional[dict]:
+        """Return ``{"refuted": bool, "reasoning": str}`` or None on failure.
+        Never raises — a verification failure must leave the original verdict
+        untouched, not abort the cycle."""
+        user = self._user_template.safe_substitute(
+            finding=json.dumps(finding, ensure_ascii=False)
+        )
+        try:
+            parsed = self._client.complete_structured(
+                model=self.model,
+                system=self._system,
+                user=user,
+                max_tokens=self.max_tokens,
+                temperature=self.temperature,
+                schema=self._schema,
+                schema_name=self.SCHEMA_NAME,
+            )
+        except Exception as exc:
+            LOG.warning(
+                "verifier failed error=%s msg=%s",
+                type(exc).__name__,
+                str(exc)[:200],
+            )
+            return None
+        return {
+            "refuted": bool(parsed.get("refuted")),
+            "reasoning": str(parsed.get("reasoning") or "").strip()[:500],
+        }
+
+
+def build_verifier(args, prompts: Prompts) -> "Optional[MaliciousVerdictVerifier]":
+    """Build the verifier when enabled and credentials exist. Returns None
+    (verification disabled) otherwise — the same credential rule as the
+    judge, since it needs an LLM client."""
+    if getattr(args, "no_verify", False):
+        return None
+    if not prompts.verifier_system:
+        LOG.warning("verifier prompt missing from prompts file; verification disabled")
+        return None
+    has_oauth = bool(os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"))
+    has_api_key = bool(
+        os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    )
+    if not has_oauth and not has_api_key:
+        return None
+    if not has_oauth and not HAS_LITELLM:
+        return None
+    try:
+        verifier = MaliciousVerdictVerifier(prompts=prompts, model=args.judge_model)
+    except RuntimeError as exc:
+        LOG.warning("MaliciousVerdictVerifier unavailable (%s); disabled", exc)
+        return None
+    LOG.info("verifier auth_mode=%s model=%s", verifier.auth_mode, verifier.model)
+    return verifier

--- a/src/avai/migrations/versions/0009_file_scan_strings.py
+++ b/src/avai/migrations/versions/0009_file_scan_strings.py
@@ -1,0 +1,41 @@
+"""file_scan.strings_json — retain a redacted sample of matched bytes
+
+Adds the strings_json column written by FileScanCollector. It carries a
+bounded, redacted sample of the bytes that actually matched each YARA rule
+([{id, offset, text|hex, truncated}]), so the judge can distinguish a
+substantive hit (a real C2 URL / mutex / command line) from a generic
+substring that points to a false positive.
+
+Guarded with a PRAGMA check: a fresh DB already has the column from
+create_all (the model carries it), so ALTER would raise "duplicate column"
+there — only an incrementally-migrated DB needs the ADD COLUMN.
+
+Revision ID: 0009_file_scan_strings
+Revises: 0008_yara_rule
+Create Date: 2026-06-17
+"""
+
+from alembic import op
+
+revision = "0009_file_scan_strings"
+down_revision = "0008_yara_rule"
+branch_labels = None
+depends_on = None
+
+
+def _has_column(bind, table: str, column: str) -> bool:
+    rows = bind.exec_driver_sql(f"PRAGMA table_info({table})").fetchall()
+    return any(r[1] == column for r in rows)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if not _has_column(bind, "file_scan", "strings_json"):
+        op.execute("ALTER TABLE file_scan ADD COLUMN strings_json VARCHAR")
+
+
+def downgrade() -> None:
+    # SQLite gained DROP COLUMN in 3.35; guard so it's a no-op when absent.
+    bind = op.get_bind()
+    if _has_column(bind, "file_scan", "strings_json"):
+        op.execute("ALTER TABLE file_scan DROP COLUMN strings_json")

--- a/src/avai/migrations/versions/0010_yara_coverage.py
+++ b/src/avai/migrations/versions/0010_yara_coverage.py
@@ -1,0 +1,49 @@
+"""yara_coverage — LLM assessment of ruleset coverage vs the host
+
+One row per assessment of how well the loaded YARA ruleset covers this
+host's threat surface (posture / headline / summary / gaps /
+recommendations). The dashboard shows the most recent row; the monitor
+regenerates only when the ruleset fingerprint changes.
+
+CREATE TABLE / INDEX IF NOT EXISTS so it's a no-op on a fresh create_all DB
+and a real create on an incrementally-migrated one.
+
+Revision ID: 0010_yara_coverage
+Revises: 0009_file_scan_strings
+Create Date: 2026-06-17
+"""
+
+from alembic import op
+
+revision = "0010_yara_coverage"
+down_revision = "0009_file_scan_strings"
+branch_labels = None
+depends_on = None
+
+_YARA_COVERAGE = """
+CREATE TABLE IF NOT EXISTS yara_coverage (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    created_at VARCHAR NOT NULL,
+    run_id VARCHAR,
+    model VARCHAR NOT NULL,
+    posture VARCHAR NOT NULL,
+    headline VARCHAR NOT NULL,
+    summary VARCHAR,
+    gaps_json VARCHAR,
+    recommendations_json VARCHAR,
+    ruleset_fingerprint VARCHAR
+)
+"""
+
+
+def upgrade() -> None:
+    op.execute(_YARA_COVERAGE)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_yara_coverage_created_at "
+        "ON yara_coverage (created_at)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_yara_coverage_created_at")
+    op.execute("DROP TABLE IF EXISTS yara_coverage")

--- a/src/avai/migrations/versions/0011_feedback.py
+++ b/src/avai/migrations/versions/0011_feedback.py
@@ -1,0 +1,46 @@
+"""feedback — operator corrections fed back into judging
+
+One row per operator correction on a finding (content_hash + collector,
+label, note, artifact). The dashboard writes these; the monitor applies them
+to the verdict and uses recent ones as host-specific ground-truth for the
+judge.
+
+CREATE TABLE / INDEX IF NOT EXISTS so it's a no-op on a fresh create_all DB
+and a real create on an incrementally-migrated one.
+
+Revision ID: 0011_feedback
+Revises: 0010_yara_coverage
+Create Date: 2026-06-17
+"""
+
+from alembic import op
+
+revision = "0011_feedback"
+down_revision = "0010_yara_coverage"
+branch_labels = None
+depends_on = None
+
+_FEEDBACK = """
+CREATE TABLE IF NOT EXISTS feedback (
+    content_hash VARCHAR NOT NULL,
+    collector VARCHAR NOT NULL,
+    label VARCHAR NOT NULL,
+    note VARCHAR,
+    artifact VARCHAR,
+    created_at VARCHAR NOT NULL,
+    applied INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (content_hash, collector)
+)
+"""
+
+
+def upgrade() -> None:
+    op.execute(_FEEDBACK)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_feedback_created_at ON feedback (created_at)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_feedback_created_at")
+    op.execute("DROP TABLE IF EXISTS feedback")

--- a/src/avai/prompts.toml
+++ b/src/avai/prompts.toml
@@ -67,6 +67,13 @@ relative to THIS host's learned-normal (not a global reputation):
   on the artifact's own merits to avoid false positives.
 - times_seen is how many cycles it has been observed; a high count with
   no other adverse signal reinforces benign.
+- intermittent=true means the artifact comes and goes — present in only
+  some of the runs since it first appeared (flapping), not steadily present.
+  That pattern fits a periodic beacon, a scheduled/triggered task, or an
+  artifact trying to evade a snapshot; treat it as more suspicious than
+  something either brand-new or steadily present, especially paired with
+  network/exec behaviour. Steady presence (intermittent=false, high
+  times_seen) reinforces benign.
 The baseline is host-context, not a verdict — external "evidence" of
 maliciousness always overrides a benign-looking baseline.
 
@@ -123,7 +130,9 @@ Return STRUCTURED fields (not prose blobs):
                             collection, command_and_control, exfiltration,
                             impact. Use "" if none fits.
                  detail   — one sentence of context, <=200 chars.
-               One timeline entry per meaningful finding; merge duplicates.
+               One timeline entry per meaningful finding; merge duplicates \
+               (the same YARA rule matching many files, or many rules on one \
+               file, is ONE event with a count — not one entry per match).
   actions    — an array of recommended actions, MOST URGENT FIRST, each:
                  priority — one of: immediate | high | medium | low.
                  title    — the action in a few words (<=80 chars).
@@ -142,6 +151,127 @@ Host has $count active non-benign finding(s). Write the incident digest.
 
 Findings (JSON):
 $findings
+"""
+
+
+[yara_coverage]
+
+system = """\
+You are a detection engineer assessing whether a host's loaded YARA ruleset
+adequately covers THAT host's actual threat surface. You are given the
+compiled ruleset (rule count, sources, and the rule count per category) and a
+host profile (platform + inventory counts: processes, installed apps, launch
+items, browser extensions, kernel/system extensions, listening ports).
+
+Judge coverage RELATIVE to this host, not in the absolute:
+- A ruleset heavy in Windows/PE-family rules is THIN coverage for a macOS or
+  Linux host, however many rules it has.
+- Weigh the host's surface: many browser extensions with no extension/JS rules
+  is a gap; lots of launch items / persistence surface with no persistence or
+  macOS-specific rules is a gap; a big installed-app footprint with no rules
+  for those vendors is a gap.
+- A small ruleset (e.g. only the bundled EICAR test rule) is THIN regardless of
+  the host — recommend fetching a pack.
+- Empty/low inventory (a freshly-started host) means judge on the ruleset's
+  breadth alone and say the host profile is still thin.
+
+Return STRUCTURED fields (not prose blobs):
+  posture   — one of: well_covered | partial | thin.
+  headline  — one line, <=120 chars, the single most important takeaway
+              (e.g. "Ruleset is Windows-centric; thin macOS persistence
+              coverage for this Mac").
+  summary   — 1-2 plain sentences (no markdown) framing the overall fit.
+  gaps      — an array of concrete coverage gaps, each an object:
+                area   — short label (<=60 chars), e.g. "macOS persistence",
+                         "browser extensions", "the installed Adobe suite".
+                detail — one sentence, <=200 chars, why it's a gap on THIS host.
+  recommendations — an array of concrete next steps, MOST IMPACTFUL FIRST,
+              each an object:
+                action — the step in a few words (<=80 chars), e.g. "fetch the
+                         signature-base pack", "add macOS LaunchAgent rules".
+                detail — one sentence, <=200 chars, what it buys you.
+
+Base everything strictly on the supplied ruleset + host profile — never invent
+rules, categories, or host facts that aren't in the data. Do not put markdown
+lists or tables in any field; the UI renders the arrays itself.
+"""
+
+user_template = """\
+Loaded YARA ruleset (JSON):
+$ruleset
+
+Host profile (JSON):
+$host
+
+Assess the ruleset's coverage of THIS host's threat surface.
+"""
+
+
+[verifier]
+
+system = """\
+You are a skeptical senior security analyst doing a SECOND review of a finding
+another analyst already labelled `malicious`. Your job is to REFUTE that label
+if it doesn't hold up — false "malicious" calls are the costliest error.
+
+You are given the artifact, any external threat-intel `evidence`, the host
+`baseline` context, correlated `related` behaviour, and the first analyst's
+`reasoning`. Decide whether the malicious verdict is genuinely supported.
+
+Set refuted=true when the malicious call is NOT well supported, e.g.:
+- it rests on heuristics / a rule name with no corroborating evidence;
+- the artifact is a signed, OS-shipped, or well-known tool flagged only for a
+  generic capability;
+- threat-intel `evidence` is absent or actually benign (CIRCL/NSRL good,
+  GreyNoise RIOT) while the reasoning ignored it;
+- the behaviour is ordinary (loopback/RFC1918, known CDNs, expected admin use).
+Set refuted=false when the malicious call IS supported — high-trust intel says
+malicious, or the artifact+behaviour clearly show C2 / persistence / exfil /
+credential theft. When in genuine doubt, do NOT refute (leave the verdict).
+
+Return: refuted (boolean) and reasoning (one or two sentences naming the
+specific signal that does or doesn't support malicious).
+"""
+
+user_template = """\
+Finding the first analyst labelled malicious (JSON):
+$finding
+
+Does the malicious verdict hold up, or should it be refuted?
+"""
+
+
+[investigator]
+
+system = """\
+You are a security analyst investigating a finding a first-pass judge could
+not classify (it returned `unknown` — insufficient information). You are now
+given a RICHER context bundle gathered specifically for this artifact: its
+full-history correlated behaviour (`related`: listening ports, outbound flows,
+remote connections, DNS, exec lineage — over all retained runs, not just the
+last cycle), external threat-intel `evidence`, the host `baseline`, and the
+host's other currently-active findings (`host_context`) so you can see whether
+this artifact is part of a larger picture.
+
+With this extra evidence, commit to a verdict. Only stay `unknown` if the
+bundle genuinely still lacks the information to decide.
+
+Return a judgment with fields:
+  verdict     — one of: $verdicts
+  category    — one of: $categories  (use `none` when not a threat indicator)
+  confidence  — float in [0, 1]
+  reasoning   — one sentence, <=200 chars, citing the evidence that decided it
+  remediation — concrete steps for non-benign; empty string "" for benign.
+Apply the same evidence rules as the first pass: high-trust malicious intel
+forces malicious; CIRCL/NSRL/RIOT good is a strong benign signal; novel +
+intermittent + adverse behaviour leans malicious.
+"""
+
+user_template = """\
+Source collector: $collector
+
+Unknown finding + investigation bundle (JSON):
+$finding
 """
 
 
@@ -165,6 +295,18 @@ IPs/domains, when present, live in this entry's `evidence` array — trust it. \
 A well-known signed process with only ordinary CDN/loopback behaviour is \
 benign. Absence of `related` data is normal (short-lived process, or \
 root-only captures unavailable) and is not itself suspicious.\
+"""
+
+network_connections = """\
+Each row is a live socket: a remote peer (raddr_ip:raddr_port) and its \
+status (ESTABLISHED, etc.). If an `evidence` array is present it holds \
+threat-intel for the remote IP — trust it. Flag: established connections to \
+public IPs flagged malicious (Feodo C2, AbuseIPDB, ThreatFox); connections \
+to raw public IPs on unusual high ports or known C2/RAT ports; a connection \
+to a destination the tcpdump flows didn't show (idle/long-lived peer). \
+Benign: loopback / RFC1918 / link-local peers, no-remote rows (listening or \
+unconnected sockets), and connections to well-known CDNs / cloud providers \
+on 443/80.\
 """
 
 listening_ports = """\
@@ -244,7 +386,14 @@ launch_items = """\
 Persistence is the primary risk. Flag: programs in /tmp, /Users/Shared, \
 /private/var/tmp, ~/Library/Caches; arguments invoking curl, wget, bash -c, \
 sh -c, base64 -d, osascript -e; RunAtLoad+KeepAlive (always-on persistence); \
-root-running labels with non-Apple bundle IDs.\
+root-running labels with non-Apple bundle IDs. \
+An entry may carry a `related` object correlating the behaviour of the \
+process this item's program is currently running: `listening_ports`, \
+`outbound_flows`, `remote_connections`, `dns_queries`, `exec_lineage`. Judge \
+the persistence item TOGETHER with that behaviour — a launch item whose \
+program is beaconing to a flagged IP or resolving DGA domains is a \
+persistence+C2 chain, far stronger than the item alone. Threat-intel for the \
+correlated IPs/domains, when present, lives in this entry's `evidence`.\
 """
 
 quarantine_events = """\
@@ -272,13 +421,24 @@ suspicious. A missing file that previously existed is suspicious.\
 """
 
 file_scan = """\
-A YARA rule matched this file — strong evidence, but not a final verdict. \
-Weigh the rule name / tags (what capability or family it signals) and any \
-attached hash threat-intel (VirusTotal, MalwareBazaar, the local \
-deny-list). A match on a signed, OS-shipped binary in a standard bin dir \
-is often a generic/heuristic rule firing on a benign tool — treat with \
-more skepticism than a match on a freshly downloaded file or an unsigned \
-binary in an app bundle.\
+A YARA rule matched this file — strong evidence, but NOT a final verdict. \
+Broad hunting rules (especially from signature-base / YARA-Forge) fire on \
+benign tools too, so your job is true-positive vs false-positive triage. \
+Weigh these together: \
+- rule name / tags — the capability or family it signals; \
+- `rule_meta` — the rule author's own description / reference / author. \
+  READ IT: it often names the exact malware family, actor, or technique. \
+- `matched_strings` — the actual bytes that fired (id, offset, text|hex). A \
+  real C2 URL, mutex, PDB path, or command line is substantive; a short \
+  generic substring is weak and points to a false positive; \
+- `evidence` — hash threat-intel for this file's sha256. \
+Reconcile contradictions EXPLICITLY: a CIRCL/NSRL known-good or signed, \
+OS-shipped binary in a standard bin dir that trips a generic rule is almost \
+always a FALSE POSITIVE → benign (say which signal cleared it). A match on a \
+freshly-downloaded or unsigned binary, or one VirusTotal / MalwareBazaar / \
+the local deny-list also flags, is far more likely a true detection. \
+When you judge it a real threat, name the malware family / actor / technique \
+from `rule_meta`/tags in `reasoning` so the user gets attribution.\
 """
 
 installed_apps = """\

--- a/src/avai/templates/partials/_file_scan.html
+++ b/src/avai/templates/partials/_file_scan.html
@@ -66,6 +66,55 @@
     </div>
   {% endif %}
 
+  {# ===== Coverage assessment (LLM: does the ruleset fit this host?) ===== #}
+  {% set cov = data.coverage if data else none %}
+  {% if cov %}
+    {% set posture_class = {"well_covered": "text-emerald-300 border-emerald-700/60 bg-emerald-900/20",
+                             "partial": "text-amber-300 border-amber-700/60 bg-amber-900/20",
+                             "thin": "text-rose-300 border-rose-700/60 bg-rose-900/20"} %}
+    <div class="mb-5 border border-slate-800 rounded-lg p-4 bg-slate-900/40">
+      <div class="flex items-center gap-2 mb-1">
+        <span class="text-[10px] uppercase tracking-wider rounded px-1.5 py-0.5 border {{ posture_class.get(cov.posture, 'text-slate-300 border-slate-700') }}">
+          {{ cov.posture.replace("_", " ") }}
+        </span>
+        <span class="text-[10px] uppercase tracking-wider text-slate-600">ruleset coverage</span>
+      </div>
+      <div class="text-sm font-medium text-slate-100">{{ cov.headline }}</div>
+      {% if cov.summary %}<div class="text-xs text-slate-400 mt-1">{{ cov.summary }}</div>{% endif %}
+
+      {% if cov.gaps %}
+        <div class="mt-3">
+          <div class="text-[10px] uppercase tracking-wider text-slate-600 mb-1">gaps</div>
+          <ul class="space-y-1">
+            {% for g in cov.gaps %}
+              <li class="text-xs text-slate-300">
+                <span class="text-slate-200 font-medium">{{ g.area }}</span>
+                {% if g.detail %}<span class="text-slate-500"> — {{ g.detail }}</span>{% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+
+      {% if cov.recommendations %}
+        <div class="mt-3">
+          <div class="text-[10px] uppercase tracking-wider text-slate-600 mb-1">recommendations</div>
+          <ul class="space-y-1">
+            {% for r in cov.recommendations %}
+              <li class="text-xs text-slate-300">
+                <span class="text-slate-200 font-medium">{{ r.action }}</span>
+                {% if r.detail %}<span class="text-slate-500"> — {{ r.detail }}</span>{% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+      {% if cov.created_at %}
+        <div class="text-[10px] uppercase tracking-wider text-slate-600 mt-3">assessed {{ cov.created_at }}</div>
+      {% endif %}
+    </div>
+  {% endif %}
+
   {# ===== Matches ===== #}
   {% if data %}
   <form id="file-scan-filters"

--- a/src/avai/templates/partials/_findings.html
+++ b/src/avai/templates/partials/_findings.html
@@ -316,6 +316,30 @@
                       last seen: <span class="text-slate-600 italic">never observed since judgement was first recorded</span>
                     {% endif %}
                   </div>
+
+                  {# ----- operator feedback: corrects this verdict + teaches
+                     the judge for this host (applied on the next cycle) ----- #}
+                  <div class="pt-2 border-t border-slate-800/60">
+                    <div class="text-[10px] uppercase tracking-widest text-slate-500 mb-1">operator feedback</div>
+                    <div id="feedback-{{ idx }}" class="flex items-center gap-2">
+                      <button type="button"
+                              class="px-2 py-0.5 rounded border border-amber-800 bg-amber-900/30 text-amber-300 text-[10px] uppercase tracking-wider hover:bg-amber-900/50 transition-colors"
+                              hx-post="/feedback/{{ f.collector }}/{{ f.content_hash }}/false_positive"
+                              hx-target="#feedback-{{ idx }}"
+                              hx-swap="innerHTML"
+                              hx-vals='{"artifact": {{ (f.artifact or "")|tojson }}}'>
+                        mark false positive
+                      </button>
+                      <button type="button"
+                              class="px-2 py-0.5 rounded border border-red-800 bg-red-900/30 text-red-300 text-[10px] uppercase tracking-wider hover:bg-red-900/50 transition-colors"
+                              hx-post="/feedback/{{ f.collector }}/{{ f.content_hash }}/confirmed"
+                              hx-target="#feedback-{{ idx }}"
+                              hx-swap="innerHTML"
+                              hx-vals='{"artifact": {{ (f.artifact or "")|tojson }}}'>
+                        confirm threat
+                      </button>
+                    </div>
+                  </div>
                 </div>
               </td>
             </tr>

--- a/src/avai/templates/partials/_vulnerabilities.html
+++ b/src/avai/templates/partials/_vulnerabilities.html
@@ -23,7 +23,20 @@
         <tbody class="divide-y divide-slate-800/80">
           {% for v in vulns %}
             <tr class="hover:bg-slate-800/40">
-              <td class="px-3 py-2 align-top font-mono text-xs text-slate-200 break-all">{{ v.software }}</td>
+              <td class="px-3 py-2 align-top font-mono text-xs text-slate-200 break-all">
+                {{ v.software }}
+                {% if v.exposed or v.running %}
+                  <div class="mt-1 flex flex-wrap gap-1">
+                    {% if v.exposed %}
+                      <span class="inline-flex items-center px-1.5 py-0.5 rounded border border-red-800 bg-red-900/30 text-red-300 text-[9px] font-semibold uppercase tracking-wider"
+                            title="A process for this software is listening on a port — reachable">exposed</span>
+                    {% elif v.running %}
+                      <span class="inline-flex items-center px-1.5 py-0.5 rounded border border-amber-800 bg-amber-900/30 text-amber-300 text-[9px] font-semibold uppercase tracking-wider"
+                            title="This software is currently running on the host">running</span>
+                    {% endif %}
+                  </div>
+                {% endif %}
+              </td>
               <td class="px-3 py-2 align-top text-xs text-slate-300">
                 {% if v.cves %}
                   <div class="flex flex-wrap gap-1.5">

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -658,6 +658,69 @@ class TestDashboardEndpoints:
         # the KEV/critical package must rank before the EOL OS
         assert body.index("openssl@3.0.2") < body.index("macos@12")
 
+    def test_vulnerabilities_flags_and_prioritises_reachable_software(self, client):
+        import json as _json
+
+        from avai.dashboard import Base
+        from avai.enrichers.cache import register_schema
+        from avai.host_monitor import CollectionRun, ListeningPortRow
+
+        model = register_schema(Base)
+        with Session(_engine_rw(app.config["DB_PATH"])) as s:
+            # A completed run where nginx is listening (exposed on the host).
+            s.add(
+                CollectionRun(
+                    run_id="run-x",
+                    started_at="2026-06-01T00:00:00Z",
+                    finished_at="2026-06-01T00:01:00Z",
+                    hostname="h",
+                    lookback_min=5,
+                )
+            )
+            s.add(
+                ListeningPortRow(
+                    run_id="run-x",
+                    collected_at="2026-06-01T00:00:00Z",
+                    process_name="nginx",
+                    laddr_ip="0.0.0.0",
+                    laddr_port=443,
+                )
+            )
+            # Exposed nginx (CVSS 5.0) vs higher-CVSS openssl that isn't present.
+            for pkg, cve, score in [
+                ("nginx@1.20", "CVE-2024-2000", 5.0),
+                ("openssl@3.0.2", "CVE-2024-3000", 9.0),
+            ]:
+                s.add(
+                    model(
+                        source="osv",
+                        indicator_type="package",
+                        indicator_value=pkg,
+                        verdict_hint="suspicious",
+                        confidence=0.6,
+                        summary="OSV",
+                        details_json=_json.dumps({"vuln_ids": [cve]}),
+                        fetched_at="2026-06-01T00:00:00Z",
+                    )
+                )
+                s.add(
+                    model(
+                        source="nvd",
+                        indicator_type="cve",
+                        indicator_value=cve,
+                        verdict_hint="malicious",
+                        confidence=0.7,
+                        summary=f"NVD: CVSS={score}",
+                        details_json=_json.dumps({"cvss31": {"baseScore": score}}),
+                        fetched_at="2026-06-01T00:00:00Z",
+                    )
+                )
+            s.commit()
+        body = client.get("/fragments/vulnerabilities").data.decode()
+        assert "exposed" in body  # the reachable-software badge rendered
+        # exposed nginx outranks the higher-CVSS but not-present openssl
+        assert body.index("nginx@1.20") < body.index("openssl@3.0.2")
+
     def test_incident_fragment_empty_shows_placeholder(self, client):
         r = client.get("/fragments/incident")
         assert r.status_code == 200
@@ -1267,5 +1330,49 @@ class TestControlPlane:
         monkeypatch.setenv("AVAI_CONTROL_TOKEN", "secret")
         r = client.post(
             "/control/maintenance/bogus", headers={"X-Avai-Token": "secret"}
+        )
+        assert r.status_code == 400
+
+
+class TestFeedbackEndpoint:
+    _HASH = "a" * 64
+
+    def test_records_feedback_with_token(self, client, monkeypatch):
+        monkeypatch.setenv("AVAI_CONTROL_TOKEN", "secret")
+        r = client.post(
+            f"/feedback/processes/{self._HASH}/false_positive",
+            data={"artifact": "curl", "note": "dev tool"},
+            headers={"X-Avai-Token": "secret"},
+        )
+        assert r.status_code == 200
+        assert b"recorded" in r.data
+        from avai.host_monitor import FeedbackRow
+
+        with Session(_engine_rw(app.config["DB_PATH"])) as s:
+            row = s.get(FeedbackRow, (self._HASH, "processes"))
+        assert row is not None
+        assert row.label == "false_positive"
+        assert row.artifact == "curl"
+        assert row.note == "dev tool"
+        assert row.applied == 0  # monitor applies it next cycle
+
+    def test_rejected_without_token(self, client, monkeypatch):
+        monkeypatch.delenv("AVAI_CONTROL_TOKEN", raising=False)
+        r = client.post(f"/feedback/processes/{self._HASH}/false_positive")
+        assert r.status_code == 403
+
+    def test_bad_label_is_400(self, client, monkeypatch):
+        monkeypatch.setenv("AVAI_CONTROL_TOKEN", "secret")
+        r = client.post(
+            f"/feedback/processes/{self._HASH}/bogus",
+            headers={"X-Avai-Token": "secret"},
+        )
+        assert r.status_code == 400
+
+    def test_unknown_collector_is_400(self, client, monkeypatch):
+        monkeypatch.setenv("AVAI_CONTROL_TOKEN", "secret")
+        r = client.post(
+            f"/feedback/not_a_collector/{self._HASH}/confirmed",
+            headers={"X-Avai-Token": "secret"},
         )
         assert r.status_code == 400

--- a/tests/test_enrichers.py
+++ b/tests/test_enrichers.py
@@ -276,6 +276,31 @@ class TestIndicatorExtraction:
         assert out[0].type is IndicatorType.IPV4
         assert out[0].value == "8.8.8.8"
 
+    def test_network_connections_emits_from_raddr_ip_fields(self):
+        # The real collector emits raddr_ip/raddr_port (not a combined raddr
+        # string); enrichment must read those so the remote IP gets intel.
+        out = extract_indicators(
+            "network_connections",
+            {"raddr_ip": "1.2.3.4", "raddr_port": 4444, "status": "ESTABLISHED"},
+        )
+        assert len(out) == 1
+        assert out[0].type is IndicatorType.IPV4
+        assert out[0].value == "1.2.3.4"
+
+    def test_network_connections_private_raddr_ip_skipped(self):
+        out = extract_indicators(
+            "network_connections",
+            {"raddr_ip": "10.0.0.5", "raddr_port": 22, "status": "ESTABLISHED"},
+        )
+        assert out == []
+
+    def test_network_connections_no_remote_yields_nothing(self):
+        out = extract_indicators(
+            "network_connections",
+            {"raddr_ip": None, "raddr_port": None, "status": "LISTEN"},
+        )
+        assert out == []
+
     def test_unknown_collector_yields_nothing(self):
         out = extract_indicators("not_a_real_collector", {"x": 1})
         assert out == []

--- a/tests/test_file_scan.py
+++ b/tests/test_file_scan.py
@@ -275,6 +275,88 @@ class TestYaraExternals:
         assert any(r["rule"] == "good" for r in rows)
 
 
+class TestMatchedStrings:
+    """The collector surfaces a bounded, redacted sample of the matched bytes
+    so the judge can triage substantive hits vs generic-substring FPs."""
+
+    def _rules(self, tmp_path: Path, body: str) -> Path:
+        d = tmp_path / "rules"
+        d.mkdir()
+        (d / "s.yar").write_text(body)
+        return d
+
+    def _scan(self, tmp_path: Path, rules: Path, name: str, write):
+        bindir = tmp_path / "bin"
+        bindir.mkdir()
+        f = bindir / name
+        write(f)
+        return list(
+            FileScanCollector(fs=_FakeFs(bin_dirs=[bindir]), rules_dir=rules).collect()
+        )
+
+    def test_printable_match_rendered_as_text(self, tmp_path):
+        rows = self._scan(
+            tmp_path,
+            _rules_dir(tmp_path),
+            "evil.bin",
+            lambda f: f.write_text(_MARKER),
+        )
+        strings = json.loads(rows[0]["strings_json"])
+        assert strings
+        s = strings[0]
+        assert s["id"] == "$a"
+        assert s["offset"] == 0
+        assert s["text"] == _MARKER
+        assert s["truncated"] is False
+        assert "hex" not in s
+
+    def test_binary_match_rendered_as_hex(self, tmp_path):
+        rules = self._rules(
+            tmp_path, "rule b { strings: $a = { DE AD BE EF } condition: $a }"
+        )
+        rows = self._scan(
+            tmp_path,
+            rules,
+            "x.bin",
+            lambda f: f.write_bytes(b"\x00\xde\xad\xbe\xef\x00"),
+        )
+        s = json.loads(rows[0]["strings_json"])[0]
+        assert s["hex"] == "deadbeef"
+        assert s["offset"] == 1
+        assert "text" not in s
+
+    def test_long_match_is_truncated(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(C, "YARA_MATCH_STRING_MAX_BYTES", 4)
+        marker = "ABCDEFGHIJ"
+        rules = self._rules(
+            tmp_path, f'rule l {{ strings: $a = "{marker}" condition: $a }}'
+        )
+        rows = self._scan(tmp_path, rules, "x.bin", lambda f: f.write_text(marker))
+        s = json.loads(rows[0]["strings_json"])[0]
+        assert s["text"] == "ABCD"
+        assert s["truncated"] is True
+
+    def test_instance_count_is_capped(self, tmp_path, monkeypatch):
+        # The marker repeats 3×; the cap must bound how many we surface.
+        monkeypatch.setattr(C, "YARA_MAX_MATCH_STRINGS", 1)
+        rows = self._scan(
+            tmp_path,
+            _rules_dir(tmp_path),
+            "x.bin",
+            lambda f: f.write_text(" ".join([_MARKER] * 3)),
+        )
+        assert len(json.loads(rows[0]["strings_json"])) == 1
+
+    def test_clean_scan_has_no_strings_rows(self, tmp_path):
+        rows = self._scan(
+            tmp_path,
+            _rules_dir(tmp_path),
+            "clean.bin",
+            lambda f: f.write_text("benign content"),
+        )
+        assert rows == []
+
+
 class TestFileType:
     def test_detects_known_magics(self, tmp_path):
         cases = {

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -55,7 +55,7 @@ def test_sink_setup_applies_migrations(tmp_path):
     Sink(create_engine(f"sqlite:///{db}")).setup()
     assert set(_IDX) <= _indexes(db)
     assert "control_state" in _tables(db)
-    assert _version(db) == "0008_yara_rule"
+    assert _version(db) == "0011_feedback"
 
 
 def test_sink_setup_fails_loudly_when_migration_cannot_apply(tmp_path, monkeypatch):
@@ -93,7 +93,7 @@ def test_upgrade_stamps_preexisting_create_all_db(tmp_path):
 
     upgrade_to_head(f"sqlite:///{db}")  # stamps baseline then adds indexes
     assert set(_IDX) <= _indexes(db)
-    assert _version(db) == "0008_yara_rule"
+    assert _version(db) == "0011_feedback"
 
 
 def test_downgrade_then_upgrade_roundtrip(tmp_path):
@@ -126,7 +126,7 @@ def test_control_state_migration_roundtrip(tmp_path):
 
     command.upgrade(_config(f"sqlite:///{db}"), "head")
     assert "control_state" in _tables(db)
-    assert _version(db) == "0008_yara_rule"
+    assert _version(db) == "0011_feedback"
 
     command.downgrade(_config(f"sqlite:///{db}"), "0002_perf_indexes")
     assert "control_state" not in _tables(db)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -9,6 +9,8 @@ just the methods that mediate enrichment + judging.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
@@ -26,6 +28,7 @@ from avai.host_monitor import (
     DEFAULT_BASELINE_MIN_RUNS,
     Base,
     CollectionRun,
+    FileScanRow,
     NullJudge,
     ProcessRow,
     Runner,
@@ -413,6 +416,30 @@ class TestAnnotateBaseline:
         runner._annotate_baseline(_ProcStub(), unjudged, bl)
         assert "baseline" not in unjudged[0]
 
+    def test_intermittent_flagged_for_flapping_artifact(self, sink):
+        # 5 runs. "steady" appears every run; "flap" only in runs 0 and 2
+        # (present in fewer runs than its window → flapping); "fresh" only in
+        # the last run (window too short to call intermittent).
+        for ts in _TS[:5]:
+            _add_run(sink, ts)
+        for ts in _TS[:5]:
+            _add_proc(sink, ts, ts, "steady")
+        for ts in (_TS[0], _TS[2]):
+            _add_proc(sink, ts, ts, "flap")
+        _add_proc(sink, _TS[4], _TS[4], "fresh")
+
+        runner = Runner(sink, [], [], NullJudge(), 5, baseline_min_runs=2)
+        bl = runner._host_baseline()
+        unjudged = [
+            {"content_hash": Digest.of_row({"name": n}, ("name",)), "name": n}
+            for n in ("steady", "flap", "fresh")
+        ]
+        runner._annotate_baseline(_ProcStub(), unjudged, bl)
+        steady, flap, fresh = unjudged
+        assert flap["baseline"]["intermittent"] is True
+        assert steady["baseline"]["intermittent"] is False  # present every run
+        assert fresh["baseline"]["intermittent"] is False  # window too short
+
 
 # ---------------------------------------------------------------------------
 # Process-story correlation
@@ -509,6 +536,65 @@ class TestAttachCorrelation:
             "signed": None,
             "exe": "/tmp/evil",
         }
+
+    def test_launch_items_correlate_via_program_to_process(self, sink):
+        # A launch item has no PID; its program is resolved to the live
+        # process running it, then that process's behaviour is attached.
+        from avai.host_monitor import LaunchItemRow, NetworkFlowRow, ProcessRow
+
+        self._setup_two_runs(sink)
+        _w(
+            sink,
+            ProcessRow,
+            pid=42,
+            name="foo",
+            exe="/usr/local/bin/foo",
+            run_id=_TS[0],
+            collected_at=_TS[0],
+        )
+        _w(
+            sink,
+            NetworkFlowRow,
+            pid=42,
+            dst_ip="9.9.9.9",
+            dst_port=443,
+            service="https",
+            packets=99,
+            run_id=_TS[0],
+            collected_at=_TS[0],
+        )
+
+        class _LaunchStub:
+            name = "launch_items"
+            model = LaunchItemRow
+            judge_fields = ("label", "program")
+            judge_hints = ""
+
+        h = "launch-hash"
+        rows = [{"content_hash": h, "program": "/usr/local/bin/foo", "label": "com.x"}]
+        unjudged = [{"content_hash": h, "label": "com.x"}]
+        runner = Runner(sink, [], [], NullJudge(), 5)
+        runner._attach_correlation(_LaunchStub(), unjudged, rows, _TS[1])
+        rel = unjudged[0]["related"]
+        assert rel["outbound_flows"][0]["dst"] == "9.9.9.9:443"
+        assert rel["outbound_flows"][0]["packets"] == 99
+
+    def test_launch_item_without_running_program_gets_no_related(self, sink):
+        from avai.host_monitor import LaunchItemRow
+
+        self._setup_two_runs(sink)
+
+        class _LaunchStub:
+            name = "launch_items"
+            model = LaunchItemRow
+            judge_fields = ("label", "program")
+            judge_hints = ""
+
+        rows = [{"content_hash": "h", "program": "/never/running", "label": "com.y"}]
+        unjudged = [{"content_hash": "h", "label": "com.y"}]
+        runner = Runner(sink, [], [], NullJudge(), 5)
+        runner._attach_correlation(_LaunchStub(), unjudged, rows, _TS[1])
+        assert "related" not in unjudged[0]
 
     def test_non_process_collector_is_not_correlated(self, sink):
         from avai.host_monitor import ListeningPortRow
@@ -1217,3 +1303,547 @@ class TestControlLoop:
         runner.run_forever(300)
         assert calls == [1]  # scan-now forced a cycle despite pause
         assert sink.read_control()["scan_now_applied"] == 1
+
+
+class _FileScanStub:
+    name = "file_scan"
+    model = FileScanRow
+    judge_enabled = True
+    judge_fields = ("path", "sha256", "rule", "namespace", "tags_json")
+    judge_hints = ""
+
+
+class TestAttachYaraContext:
+    """The Runner surfaces a YARA hit's rule meta + matched bytes to the
+    judge without touching the content_hash (they aren't judge_fields)."""
+
+    def _runner(self, sink):
+        return Runner(sink, [], [], _RecordingJudge(), 5)
+
+    def test_attaches_meta_and_strings_from_row(self, sink):
+        runner = self._runner(sink)
+        h = "hash-1"
+        rows = [
+            {
+                "content_hash": h,
+                "meta_json": json.dumps(
+                    {"author": "Jane", "description": "APT42 implant loader"}
+                ),
+                "strings_json": json.dumps(
+                    [{"id": "$c2", "offset": 16, "text": "http://evil.example/x"}]
+                ),
+            }
+        ]
+        unjudged = [{"content_hash": h, "rule": "apt42_loader"}]
+        runner._attach_yara_context(_FileScanStub(), unjudged, rows)
+        assert unjudged[0]["rule_meta"]["description"] == "APT42 implant loader"
+        assert unjudged[0]["matched_strings"][0]["text"] == "http://evil.example/x"
+
+    def test_other_collectors_are_untouched(self, sink):
+        runner = self._runner(sink)
+        unjudged = [{"content_hash": "h", "name": "x"}]
+        # _StubCollector.name is "processes" — not the file_scan collector.
+        runner._attach_yara_context(
+            _StubCollector(), unjudged, [{"content_hash": "h", "meta_json": "{}"}]
+        )
+        assert "rule_meta" not in unjudged[0]
+        assert "matched_strings" not in unjudged[0]
+
+    def test_missing_and_malformed_json_is_tolerated(self, sink):
+        runner = self._runner(sink)
+        h = "hash-2"
+        # No meta, malformed strings — neither key should be attached, no raise.
+        rows = [{"content_hash": h, "strings_json": "{not json"}]
+        unjudged = [{"content_hash": h, "rule": "r"}]
+        runner._attach_yara_context(_FileScanStub(), unjudged, rows)
+        assert "rule_meta" not in unjudged[0]
+        assert "matched_strings" not in unjudged[0]
+
+    def test_entry_without_matching_row_is_skipped(self, sink):
+        runner = self._runner(sink)
+        unjudged = [{"content_hash": "absent", "rule": "r"}]
+        runner._attach_yara_context(
+            _FileScanStub(), unjudged, [{"content_hash": "other", "meta_json": "{}"}]
+        )
+        assert "rule_meta" not in unjudged[0]
+
+
+# ---------------------------------------------------------------------------
+# YARA ruleset-coverage assessment
+# ---------------------------------------------------------------------------
+
+
+class _FakeAssessor:
+    model = "fake-cov-model"
+
+    def __init__(self, result=None):
+        self.calls = []
+        self._result = result or {
+            "posture": "thin",
+            "headline": "Windows-centric ruleset on a Mac",
+            "summary": "Few macOS rules for this host's surface.",
+            "gaps": [{"area": "macOS persistence", "detail": "no LaunchAgent rules"}],
+            "recommendations": [
+                {"action": "fetch signature-base", "detail": "adds macOS coverage"}
+            ],
+        }
+
+    def assess(self, ruleset, host):
+        self.calls.append((ruleset, host))
+        return self._result
+
+
+def _seed_yara_status(sink, rules_loaded=10, sources=None, by_category=None):
+    sink.write_yara_status(
+        {
+            "rules_loaded": rules_loaded,
+            "files_loaded": rules_loaded,
+            "files_skipped": 0,
+            "rules_dir": "/rules",
+            "sources": sources or {"bundled": rules_loaded},
+            "skip_reasons": {},
+            "by_category": by_category or {"gen": rules_loaded},
+        }
+    )
+
+
+def _latest_coverage_row(sink):
+    from sqlalchemy import desc, select
+
+    from avai.host_monitor import YaraCoverageRow
+
+    with Session(sink.engine) as s:
+        return (
+            s.execute(
+                select(YaraCoverageRow).order_by(desc(YaraCoverageRow.created_at))
+            )
+            .scalars()
+            .first()
+        )
+
+
+class TestGenerateCoverage:
+    def _runner(self, sink, assessor):
+        return Runner(sink, [], [], NullJudge(), 5, coverage=assessor)
+
+    def test_no_ruleset_no_assessment(self, sink):
+        a = _FakeAssessor()
+        self._runner(sink, a)._generate_coverage("run-1", _TS[1])
+        assert a.calls == []
+        assert sink.latest_yara_coverage_fingerprint() is None
+
+    def test_zero_rules_no_assessment(self, sink):
+        _seed_yara_status(sink, rules_loaded=0)
+        a = _FakeAssessor()
+        self._runner(sink, a)._generate_coverage("run-1", _TS[1])
+        assert a.calls == []
+
+    def test_assessment_generated_and_stored(self, sink):
+        _seed_yara_status(sink)
+        a = _FakeAssessor()
+        self._runner(sink, a)._generate_coverage("run-1", _TS[1])
+        assert len(a.calls) == 1
+        # The host profile passed carries the platform + inventory counts.
+        _ruleset, host = a.calls[0]
+        assert "platform" in host and "processes" in host
+        row = _latest_coverage_row(sink)
+        assert row.posture == "thin"
+        assert row.headline.startswith("Windows-centric")
+        assert json.loads(row.gaps_json)[0]["area"] == "macOS persistence"
+        assert row.ruleset_fingerprint  # stored for dedup
+
+    def test_unchanged_ruleset_not_regenerated(self, sink):
+        _seed_yara_status(sink)
+        a = _FakeAssessor()
+        r = self._runner(sink, a)
+        r._generate_coverage("run-1", _TS[1])
+        r._generate_coverage("run-2", _TS[1])
+        assert len(a.calls) == 1  # same ruleset fingerprint → skipped
+
+    def test_changed_ruleset_regenerates(self, sink):
+        _seed_yara_status(sink, rules_loaded=10)
+        a = _FakeAssessor()
+        r = self._runner(sink, a)
+        r._generate_coverage("run-1", _TS[1])
+        _seed_yara_status(sink, rules_loaded=99)  # ruleset changed
+        r._generate_coverage("run-2", _TS[1])
+        assert len(a.calls) == 2
+
+
+class TestYaraCoverageAssessor:
+    def _assessor(self, payload):
+        from avai.host_monitor import DEFAULT_PROMPTS_PATH, Prompts
+        from avai.host_monitor.coverage import YaraCoverageAssessor
+
+        class _FakeClient:
+            def __init__(self):
+                self.calls = []
+
+            def complete_structured(self, **kw):
+                self.calls.append(kw)
+                return payload
+
+        return YaraCoverageAssessor(
+            prompts=Prompts.load(DEFAULT_PROMPTS_PATH), client=_FakeClient()
+        )
+
+    _RULESET = {"rules_loaded": 5, "sources": {"bundled": 5}, "by_category": {"gen": 5}}
+
+    def test_prompt_section_loads(self):
+        from avai.host_monitor import DEFAULT_PROMPTS_PATH, Prompts
+
+        p = Prompts.load(DEFAULT_PROMPTS_PATH)
+        assert p.coverage_system and "$ruleset" in p.coverage_user_template
+
+    def test_empty_ruleset_returns_none_without_calling_llm(self):
+        a = self._assessor({"posture": "thin", "headline": "h", "summary": "s"})
+        assert a.assess({}, {"platform": "Darwin"}) is None
+        assert a.assess({"rules_loaded": 0}, {}) is None
+
+    def test_bad_posture_falls_back_to_partial(self):
+        a = self._assessor(
+            {
+                "posture": "fortified",
+                "headline": "h",
+                "summary": "s",
+                "gaps": [],
+                "recommendations": [],
+            }
+        )
+        out = a.assess(self._RULESET, {"platform": "Darwin"})
+        assert out["posture"] == "partial"
+
+    def test_missing_headline_returns_none(self):
+        a = self._assessor({"posture": "thin", "summary": "s", "gaps": []})
+        assert a.assess(self._RULESET, {}) is None
+
+    def test_gaps_and_recommendations_normalised(self):
+        a = self._assessor(
+            {
+                "posture": "thin",
+                "headline": "h",
+                "summary": "s",
+                "gaps": [
+                    {"area": "macOS", "detail": "d"},
+                    {"detail": "no area → dropped"},
+                ],
+                "recommendations": [
+                    {"action": "fetch pack", "detail": "d"},
+                    {"detail": "no action → dropped"},
+                ],
+            }
+        )
+        out = a.assess(self._RULESET, {"platform": "Darwin"})
+        assert len(out["gaps"]) == 1 and out["gaps"][0]["area"] == "macOS"
+        assert len(out["recommendations"]) == 1
+        assert out["recommendations"][0]["action"] == "fetch pack"
+
+
+# ---------------------------------------------------------------------------
+# Malicious-verdict verifier (adversarial second pass)
+# ---------------------------------------------------------------------------
+
+
+def _mk_judgment(h, verdict, collector="processes"):
+    from avai.host_monitor import Judgment, ThreatCategory
+
+    return Judgment(
+        content_hash=h,
+        collector=collector,
+        verdict=verdict,
+        category=ThreatCategory.PERSISTENCE,
+        confidence=0.9,
+        reasoning="original reason",
+        remediation="",
+        model="m",
+        created_at="2026-01-01T00:00:00Z",
+    )
+
+
+class _FakeVerifier:
+    def __init__(self, refuted):
+        self._refuted = refuted
+        self.calls = []
+
+    def verify(self, finding):
+        self.calls.append(finding)
+        return {"refuted": self._refuted, "reasoning": "skeptic says so"}
+
+
+class TestVerifyJudgments:
+    def _runner(self, sink, verifier=None):
+        return Runner(sink, [], [], NullJudge(), 5, verifier=verifier)
+
+    def test_refuted_malicious_downgraded_to_suspicious(self, sink):
+        from avai.host_monitor import Verdict
+
+        v = _FakeVerifier(refuted=True)
+        j = _mk_judgment("h1", Verdict.MALICIOUS)
+        out = self._runner(sink, v)._verify_judgments(
+            "processes", [j], [{"content_hash": "h1", "name": "x"}]
+        )
+        assert out[0].verdict == Verdict.SUSPICIOUS
+        assert "downgraded" in out[0].reasoning
+        assert "original reason" in out[0].reasoning  # original preserved
+        assert len(v.calls) == 1
+
+    def test_unrefuted_malicious_is_kept(self, sink):
+        from avai.host_monitor import Verdict
+
+        v = _FakeVerifier(refuted=False)
+        j = _mk_judgment("h1", Verdict.MALICIOUS)
+        out = self._runner(sink, v)._verify_judgments(
+            "processes", [j], [{"content_hash": "h1"}]
+        )
+        assert out[0].verdict == Verdict.MALICIOUS
+        assert len(v.calls) == 1
+
+    def test_non_malicious_is_not_verified(self, sink):
+        from avai.host_monitor import Verdict
+
+        v = _FakeVerifier(refuted=True)
+        j = _mk_judgment("h1", Verdict.SUSPICIOUS)
+        out = self._runner(sink, v)._verify_judgments("processes", [j], [])
+        assert out[0].verdict == Verdict.SUSPICIOUS
+        assert v.calls == []  # skeptic only runs on malicious
+
+    def test_no_verifier_is_noop(self, sink):
+        from avai.host_monitor import Verdict
+
+        j = _mk_judgment("h1", Verdict.MALICIOUS)
+        out = self._runner(sink)._verify_judgments("processes", [j], [])
+        assert out[0].verdict == Verdict.MALICIOUS
+
+
+class TestMaliciousVerdictVerifier:
+    def _verifier(self, payload):
+        from avai.host_monitor import DEFAULT_PROMPTS_PATH, Prompts
+        from avai.host_monitor.verifier import MaliciousVerdictVerifier
+
+        class _FakeClient:
+            def __init__(self):
+                self.calls = []
+
+            def complete_structured(self, **kw):
+                self.calls.append(kw)
+                return payload
+
+        return MaliciousVerdictVerifier(
+            prompts=Prompts.load(DEFAULT_PROMPTS_PATH), client=_FakeClient()
+        )
+
+    def test_refuted_true_parsed(self):
+        out = self._verifier(
+            {"refuted": True, "reasoning": "signed Apple binary"}
+        ).verify({"artifact": "x"})
+        assert out["refuted"] is True
+        assert "signed" in out["reasoning"]
+
+    def test_missing_fields_default_to_not_refuted(self):
+        # Absent/garbled output must not silently downgrade a verdict.
+        out = self._verifier({}).verify({"artifact": "x"})
+        assert out["refuted"] is False
+
+
+# ---------------------------------------------------------------------------
+# Unknown-finding investigator (deep re-judge)
+# ---------------------------------------------------------------------------
+
+
+class _FakeInvestigator:
+    def __init__(self, verdict, category=None):
+        from avai.host_monitor import ThreatCategory
+
+        self._verdict = verdict
+        self._category = category or ThreatCategory.COMMAND_AND_CONTROL
+        self.calls = []
+
+    def investigate(self, collector, finding):
+        self.calls.append((collector, finding))
+        return {
+            "verdict": self._verdict,
+            "category": self._category,
+            "confidence": 0.8,
+            "reasoning": "deep look decided it",
+            "remediation": "do x",
+        }
+
+
+class TestInvestigateUnknowns:
+    def _runner(self, sink, investigator=None):
+        return Runner(sink, [], [], NullJudge(), 5, investigator=investigator)
+
+    def test_unknown_resolved_replaces_verdict(self, sink):
+        from avai.host_monitor import Verdict
+
+        inv = _FakeInvestigator(Verdict.MALICIOUS)
+        j = _mk_judgment("h1", Verdict.UNKNOWN)
+        out = self._runner(sink, inv)._investigate_unknowns(
+            _ProcStub(), [j], [{"content_hash": "h1", "name": "evil"}], []
+        )
+        assert out[0].verdict == Verdict.MALICIOUS
+        assert out[0].reasoning.startswith("[investigated]")
+        assert len(inv.calls) == 1
+
+    def test_unknown_kept_when_still_unknown(self, sink):
+        from avai.host_monitor import Verdict
+
+        inv = _FakeInvestigator(Verdict.UNKNOWN)
+        j = _mk_judgment("h1", Verdict.UNKNOWN)
+        out = self._runner(sink, inv)._investigate_unknowns(
+            _ProcStub(), [j], [{"content_hash": "h1"}], []
+        )
+        assert out[0].verdict == Verdict.UNKNOWN
+        assert len(inv.calls) == 1  # investigated, but couldn't commit
+
+    def test_non_unknown_not_investigated(self, sink):
+        from avai.host_monitor import Verdict
+
+        inv = _FakeInvestigator(Verdict.MALICIOUS)
+        j = _mk_judgment("h1", Verdict.SUSPICIOUS)
+        out = self._runner(sink, inv)._investigate_unknowns(_ProcStub(), [j], [], [])
+        assert out[0].verdict == Verdict.SUSPICIOUS
+        assert inv.calls == []
+
+    def test_no_investigator_is_noop(self, sink):
+        from avai.host_monitor import Verdict
+
+        j = _mk_judgment("h1", Verdict.UNKNOWN)
+        out = self._runner(sink)._investigate_unknowns(_ProcStub(), [j], [], [])
+        assert out[0].verdict == Verdict.UNKNOWN
+
+    def test_finding_carries_full_history_behaviour(self, sink):
+        from avai.host_monitor import NetworkFlowRow, Verdict
+
+        # A flow for pid 42 in history (no run-time bound applies under
+        # investigation), resolved via the process row passed in.
+        _w(
+            sink,
+            NetworkFlowRow,
+            pid=42,
+            dst_ip="9.9.9.9",
+            dst_port=443,
+            service="https",
+            packets=5,
+            run_id="r0",
+            collected_at=_TS[0],
+        )
+        inv = _FakeInvestigator(Verdict.MALICIOUS)
+        j = _mk_judgment("h1", Verdict.UNKNOWN)
+        rows = [{"content_hash": "h1", "pid": 42, "name": "evil"}]
+        self._runner(sink, inv)._investigate_unknowns(
+            _ProcStub(), [j], [{"content_hash": "h1", "name": "evil"}], rows
+        )
+        _collector, finding = inv.calls[0]
+        assert finding["related_full"]["outbound_flows"][0]["dst"] == "9.9.9.9:443"
+
+
+class TestUnknownFindingInvestigator:
+    def _inv(self, payload):
+        from avai.host_monitor import DEFAULT_PROMPTS_PATH, Prompts
+        from avai.host_monitor.investigator import UnknownFindingInvestigator
+
+        class _FakeClient:
+            def complete_structured(self, **kw):
+                return payload
+
+        return UnknownFindingInvestigator(
+            prompts=Prompts.load(DEFAULT_PROMPTS_PATH), client=_FakeClient()
+        )
+
+    def test_parses_and_clamps(self):
+        from avai.host_monitor import ThreatCategory, Verdict
+
+        out = self._inv(
+            {
+                "verdict": "malicious",
+                "category": "command_and_control",
+                "confidence": 1.5,
+                "reasoning": "r",
+                "remediation": "x",
+            }
+        ).investigate("processes", {"a": 1})
+        assert out["verdict"] == Verdict.MALICIOUS
+        assert out["category"] == ThreatCategory.COMMAND_AND_CONTROL
+        assert out["confidence"] == 1.0  # clamped to [0,1]
+
+    def test_bad_verdict_coerces_to_unknown(self):
+        from avai.host_monitor import Verdict
+
+        out = self._inv(
+            {
+                "verdict": "scary",
+                "category": "nope",
+                "confidence": 0.5,
+                "reasoning": "r",
+                "remediation": "",
+            }
+        ).investigate("processes", {})
+        assert out["verdict"] == Verdict.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Operator feedback loop
+# ---------------------------------------------------------------------------
+
+
+def _add_feedback(sink, h, collector, label, note=None, artifact=None, applied=0):
+    from avai.host_monitor import FeedbackRow
+
+    with Session(sink.engine) as s:
+        s.add(
+            FeedbackRow(
+                content_hash=h,
+                collector=collector,
+                label=label,
+                note=note,
+                artifact=artifact,
+                created_at="2026-01-01T00:00:00Z",
+                applied=applied,
+            )
+        )
+        s.commit()
+
+
+class TestFeedback:
+    def test_apply_feedback_flips_to_benign_and_marks_applied(self, sink):
+        from avai.host_monitor import Judgement, Verdict
+
+        _add_judgement(sink, "h1", "malicious", last_seen=_TS[1])
+        _add_feedback(sink, "h1", "processes", "false_positive", note="known dev tool")
+        assert sink.apply_feedback() == 1
+        with Session(sink.engine) as s:
+            row = s.get(Judgement, ("h1", "processes"))
+        assert row.verdict == str(Verdict.BENIGN)
+        assert "operator" in row.reasoning and "known dev tool" in row.reasoning
+        assert sink.apply_feedback() == 0  # already applied → not reprocessed
+
+    def test_apply_feedback_confirmed_to_malicious(self, sink):
+        from avai.host_monitor import Judgement, Verdict
+
+        _add_judgement(sink, "h2", "suspicious", last_seen=_TS[1])
+        _add_feedback(sink, "h2", "processes", "confirmed")
+        sink.apply_feedback()
+        with Session(sink.engine) as s:
+            row = s.get(Judgement, ("h2", "processes"))
+        assert row.verdict == str(Verdict.MALICIOUS)
+
+    def test_feedback_examples_scoped_to_collector(self, sink):
+        _add_feedback(sink, "h1", "processes", "false_positive", artifact="curl")
+        ex = sink.feedback_examples("processes")
+        assert ex and ex[0]["artifact"] == "curl"
+        assert ex[0]["label"] == "false_positive"
+        assert sink.feedback_examples("dns_queries") == []
+
+    def test_judge_hints_appends_ground_truth_block(self, sink):
+        _add_feedback(
+            sink, "h1", "processes", "false_positive", artifact="curl", note="dev tool"
+        )
+        runner = Runner(sink, [], [], NullJudge(), 5)
+        hints = runner._judge_hints("processes", "BASE HINTS")
+        assert hints.startswith("BASE HINTS")
+        assert "curl" in hints and "FALSE POSITIVE" in hints and "dev tool" in hints
+
+    def test_judge_hints_unchanged_without_feedback(self, sink):
+        runner = Runner(sink, [], [], NullJudge(), 5)
+        assert runner._judge_hints("processes", "BASE") == "BASE"


### PR DESCRIPTION
Makes the threat judge more intelligent end-to-end (not a single stateless per-collector classification). All second stages are credential-gated and independently toggleable; full suite green (840 tests).

## YARA judgement quality
- surface matched-rule meta + a redacted sample of matched bytes to the judge (`file_scan.strings_json`) for FP triage + attribution
- assess whether the loaded ruleset covers this host (`yara_coverage`)

## Richer per-finding context
- exploitability: flag CVE/EOL software actually running/exposed; prioritise reachable + actively-exploited
- judge `network_connections` on the remote endpoint (fix extractor to read `raddr_ip/raddr_port`)
- behavioural drift: flag intermittent (flapping) artifacts
- correlate `launch_items` with the behaviour of the process they spawn

## Second-pass intelligence
- **verify**: adversarial skeptic downgrades unsupported `malicious` verdicts (`--no-verify`)
- **investigate**: re-judge `unknown` findings with full-history context (`--no-investigate`)
- **feedback**: operators mark FP/confirmed; monitor corrects the verdict and feeds it back to the judge as host ground-truth

Adds migrations 0009–0011 and the verifier/investigator/coverage modules.