### PR TITLE
v0.7.0 — LLM judge ships by default (pip install avai-monitor)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install package + test deps
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,judge]"
+          pip install -e ".[dev]"
 
       - name: Lint (ruff)
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to **avai** (PyPI: `avai-monitor`, Docker:
 `iklob1/avai`). Versions follow semantic versioning.
 
+## [0.7.0] — 2026-06-17
+
+### Changed
+- **The LLM threat judge ships by default.** `litellm` and `anthropic` moved from the optional `[judge]` extra into the base dependencies, so a plain `pip install avai-monitor` installs the judge — the core feature — with no extra to remember. The `[judge]` extra has been removed; `pip install 'avai-monitor[judge]'` should become `pip install avai-monitor` (the Docker image, README, landing page, and CI were updated to match). A runtime credential (`CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`) is still required to judge; without one the monitor falls back to `NullJudge` as before. Note: this enlarges the default install footprint (litellm + anthropic and their transitive deps).
+
 ## [0.6.0] — 2026-06-17
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # avai itself.
 COPY pyproject.toml README.md ./
 COPY src ./src
-RUN pip install '.[judge]' \
+RUN pip install '.' \
  && mkdir -p /data
 
 EXPOSE 8765

--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ the simplest way to watch a server is to install it natively and let
 it see everything directly:
 
 ```sh
-pip install 'avai-monitor[judge]'          # [judge] pulls litellm + anthropic
+pip install avai-monitor                    # includes the LLM judge (litellm + anthropic)
 export ANTHROPIC_API_KEY=sk-ant-...         # or CLAUDE_CODE_OAUTH_TOKEN
 export ABUSE_CH_AUTH_KEY=...                # optional, free — adds 3 sources
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 # differs, because the canonical `avai` slot is blocked by PyPI's
 # name-similarity policy.
 name = "avai-monitor"
-version = "0.6.0"
+version = "0.7.0"
 description = "macOS / Linux host-security telemetry collector with an LLM threat judge and a single-page web dashboard."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -65,14 +65,14 @@ dependencies = [
     # YARA signature scanning (FileScanCollector). Wheels bundle libyara for
     # manylinux + macOS, so no separate system install is needed on those.
     "yara-python>=4.5",
-]
-
-[project.optional-dependencies]
-# Pull these in with: pip install 'avai-monitor[judge]'
-judge = [
+    # The LLM threat judge is core, so its providers ship by default — a plain
+    # `pip install avai-monitor` runs the judge (you still supply an API key /
+    # OAuth token at runtime; without one it falls back to NullJudge).
     "litellm>=1.0",
     "anthropic>=0.30",
 ]
+
+[project.optional-dependencies]
 dev = [
     "build>=1.0",
     "twine>=5.0",

--- a/src/avai/__init__.py
+++ b/src/avai/__init__.py
@@ -13,4 +13,4 @@ Or programmatically:
     from avai.dashboard import app as dashboard_app
 """
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/web/components/landing/Hero.tsx
+++ b/web/components/landing/Hero.tsx
@@ -39,9 +39,7 @@ export function Hero() {
         </div>
         <p className="mx-auto mt-3 max-w-xl text-sm text-slate-500">
           Prefer native?{" "}
-          <code className="mono text-slate-400">
-            pip install &apos;avai-monitor[judge]&apos;
-          </code>
+          <code className="mono text-slate-400">pip install avai-monitor</code>
         </p>
         <a
           href="https://github.com/iklobato/avai"

--- a/web/components/landing/sections.tsx
+++ b/web/components/landing/sections.tsx
@@ -382,13 +382,13 @@ export function GetStarted() {
     {
       title: "pip (macOS or Linux)",
       tag: "",
-      body: "pip install 'avai-monitor[judge]'",
+      body: "pip install avai-monitor",
     },
   ];
   const recipes = [
     {
       title: "🔑 Turn on the AI verdicts",
-      body: "Set your LLM key and run with [judge].",
+      body: "Set your LLM key (the judge ships by default) and run.",
     },
     {
       title: "🖥️ Watch a Linux server, keep it running",


### PR DESCRIPTION
Moves `litellm` + `anthropic` from the optional `[judge]` extra into the base dependencies and removes the extra, so `pip install avai-monitor` installs the LLM threat judge (the core feature) out of the box.

- All install references updated to drop `[judge]`: README, Dockerfile (`.[judge]` → `.`), CI (`.[dev,judge]` → `.[dev]`), landing page (Hero + get-started grid).
- Runtime credential still required (`CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`); falls back to NullJudge without one.
- Version bumped to 0.7.0 + CHANGELOG.
- Note: default install footprint grows (litellm + anthropic transitive deps).

Verified: `pip install -e .` resolves, litellm+anthropic import, 107 dashboard/file_scan tests pass, web `tsc` clean.