### PR TITLE
landing: hero version badge → v0.7.0

### DIFF
--- a/web/components/landing/Hero.tsx
+++ b/web/components/landing/Hero.tsx
@@ -11,7 +11,7 @@ export function Hero() {
   return (
     <section className="mx-auto max-w-6xl px-6 pt-16 pb-12 text-center">
       <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-300">
-        <span className="pulse-dot" /> v0.5.0 — open source, MIT licensed
+        <span className="pulse-dot" /> v0.7.0 — open source, MIT licensed
       </span>
       <h1 className="mx-auto mt-6 max-w-3xl text-4xl font-bold leading-tight sm:text-5xl">
         <span className="grad-text">


### PR DESCRIPTION
Updates the landing hero badge from v0.5.0 to v0.7.0 to match the current release. Docs/markdown were already current (pip-without-extra, docker-primary).