### PR TITLE
v0.7.1 — container runs monitor + dashboard together (supervisord)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to **avai** (PyPI: `avai-monitor`, Docker:
 `iklob1/avai`). Versions follow semantic versioning.
 
+## [0.7.1] — 2026-06-17
+
+### Changed
+- **The Docker image runs the monitor and the dashboard together by default.** A plain `docker run -p 8765:8765 -v "$PWD":/data iklob1/avai` now starts both roles under supervisord, so the dashboard is populated out of the box instead of showing an empty database. They share `/data/avai.db` (the monitor writes; the dashboard reads it live), each streams to the container's stdout/stderr, and supervisord restarts either one if it exits. Override the command to run a single role (`… iklob1/avai avai dashboard` or `… avai monitor`). For full host visibility on Linux, still add `--pid=host --network=host`; the LLM judge still needs a credential (`CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`) or it falls back to NullJudge.
+
+### Fixed
+- **The dashboard no longer crashes when `/etc/hosts` can't be replaced** (e.g. in a container, where it's a bind-mounted file and `os.replace` fails with `EBUSY`). The hosts-file writer now surfaces OS-level write failures as `HostsError`, so the optional `avai.local` mapping degrades to a quiet notice — as its docstring already promised — instead of taking down the server. `avai install-hosts` likewise reports a clean error rather than a traceback.
+
 ## [0.7.0] — 2026-06-17
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,20 @@
-# avai — single image, two roles.
+# avai — single image, two roles, run together.
 #
 # Same image is used for both `avai dashboard` and `avai monitor`. The
 # monitor's Linux userland (iw, systemctl, journalctl, dmsetup, bluez)
 # is included unconditionally — adds ~80 MB but keeps the publish/pull
 # story to one image per architecture.
 #
-# Default CMD is the dashboard (most common standalone use). Override
-# the command at `docker run` / compose level to invoke the monitor:
+# Default CMD runs BOTH the monitor and the dashboard under supervisord,
+# so the dashboard is populated out of the box:
 #
 #   docker run -p 8765:8765 -v "$PWD":/data iklob1/avai
-#   docker run --pid=host --network=host ... iklob1/avai \
-#       avai monitor --db /data/avai.db
+#
+# For full host visibility on Linux, add --pid=host --network=host.
+# Override the command to run a single role instead:
+#
+#   docker run -p 8765:8765 -v "$PWD":/data iklob1/avai avai dashboard
+#   docker run --pid=host --network=host ... iklob1/avai avai monitor
 
 ARG PYTHON_VERSION=3.11
 FROM python:${PYTHON_VERSION}-slim
@@ -34,11 +38,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
-# avai itself.
+# avai itself, plus supervisord to run the two roles together.
 COPY pyproject.toml README.md ./
 COPY src ./src
-RUN pip install '.' \
+RUN pip install '.' supervisor \
  && mkdir -p /data
+COPY docker/supervisord.conf /etc/supervisor/avai.conf
 
 EXPOSE 8765
 
@@ -51,8 +56,6 @@ HEALTHCHECK --interval=30s --timeout=4s --start-period=5s --retries=3 \
   CMD python -c "import urllib.request,sys; \
 sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8765/api/notifications/new?since=2099-01-01', timeout=3).status==200 else 1)"
 
-# Default = dashboard. Override with `avai monitor ...` for the
-# collector role.
-CMD ["avai", "dashboard", \
-     "--host", "0.0.0.0", "--port", "8765", \
-     "--db", "/data/avai.db"]
+# Default = monitor + dashboard together, via supervisord. Override with
+# `avai dashboard` / `avai monitor ...` to run a single role.
+CMD ["supervisord", "-c", "/etc/supervisor/avai.conf"]

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ malicious/suspicious findings.
 
 **Built to stay out of your way**
 
-- **One `docker run`** — the same image is both the dashboard and the monitor.
+- **One `docker run`** — one image runs the monitor *and* the dashboard together (via supervisord), so it's populated out of the box.
 - **No agent contract, no SIEM, no cloud control plane** — it runs on your host.
 - **Dedup by content hash** — the same artifact is never sent to the LLM twice.
 - **Just a SQLite file** — point the dashboard at any `avai.db`, on any OS.
@@ -172,13 +172,18 @@ Full reference below: [What's collected](#whats-collected-one-line-summary) ·
 
 | Run | Command | Where it makes sense |
 |---|---|---|
-| Dashboard (default) | `docker run iklob1/avai` | any host — read-only Flask + HTMX on :8765 |
-| Monitor | `docker run ... iklob1/avai avai monitor ...` | **Linux hosts only** — needs `pid=host`, `network=host`, and host filesystem bind-mounts |
+| Monitor + dashboard (default) | `docker run -p 8765:8765 -v "$PWD":/data iklob1/avai` | any host — runs both under supervisord; dashboard on :8765 populated by the in-container monitor |
+| Full host visibility (Linux) | `docker run --pid=host --network=host ... iklob1/avai` | **Linux hosts** — the in-container monitor sees the real host |
+| Single role | `docker run ... iklob1/avai avai dashboard` (or `avai monitor`) | run just one role (e.g. dashboard against an existing `avai.db`, or a monitor-only container) |
 
-The image's default `CMD` is the dashboard. Override the command at
-`docker run` / compose level to run the monitor instead. Native install
-is also possible (`pip install avai-monitor`, then `avai monitor` /
-`avai dashboard`) but is not the documented path.
+The image's default `CMD` runs both roles together via supervisord (they
+share `/data/avai.db` — the monitor writes, the dashboard reads it live —
+and either is auto-restarted if it exits). Override the command to run a
+single role. The LLM judge still needs a credential at runtime
+(`-e CLAUDE_CODE_OAUTH_TOKEN=…` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`);
+without one the monitor falls back to NullJudge (collection only). Native
+install also works: `pip install avai-monitor`, then `avai monitor` /
+`avai dashboard`.
 
 The image carries a `HEALTHCHECK` against the dashboard's
 `/api/notifications/new` endpoint — `starting → healthy` in ~10 s on

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,0 +1,36 @@
+# Runs the monitor and the dashboard together in one container so a plain
+# `docker run -p 8765:8765 -v "$PWD":/data iklob1/avai` gives a populated
+# dashboard out of the box. Both share /data/avai.db — the monitor writes,
+# the dashboard reads it live (mode=ro, no immutable, so it sees WAL writes).
+# Each program streams to the container's stdout/stderr so `docker logs`
+# shows both. Override the image CMD (e.g. `avai dashboard`) to run a single
+# role instead.
+
+[supervisord]
+nodaemon=true
+user=root
+logfile=/dev/null
+logfile_maxbytes=0
+pidfile=/tmp/supervisord.pid
+
+[program:monitor]
+command=avai monitor --db /data/avai.db
+autostart=true
+autorestart=true
+startsecs=3
+priority=10
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0
+
+[program:dashboard]
+command=avai dashboard --host 0.0.0.0 --port 8765 --db /data/avai.db
+autostart=true
+autorestart=true
+startsecs=3
+priority=20
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 # differs, because the canonical `avai` slot is blocked by PyPI's
 # name-similarity policy.
 name = "avai-monitor"
-version = "0.7.0"
+version = "0.7.1"
 description = "macOS / Linux host-security telemetry collector with an LLM threat judge and a single-page web dashboard."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/avai/__init__.py
+++ b/src/avai/__init__.py
@@ -13,4 +13,4 @@ Or programmatically:
     from avai.dashboard import app as dashboard_app
 """
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/src/avai/hostsfile.py
+++ b/src/avai/hostsfile.py
@@ -232,9 +232,17 @@ def _validate_hostname(hostname: str) -> None:
 def _atomic_write(path: Path, text: str) -> None:
     """Write ``text`` to ``path`` via a same-directory temp file + ``os.replace``
     so a crash mid-write can't leave a truncated hosts file. Preserves the
-    existing file mode (hosts files are world-readable, 0644)."""
-    mode = path.stat().st_mode & 0o777 if path.exists() else 0o644
-    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".avai-hosts-")
+    existing file mode (hosts files are world-readable, 0644).
+
+    Any OS-level write failure (no privilege, parent unwritable, or — in a
+    container — the bind-mounted ``/etc/hosts`` that ``os.replace`` can't
+    replace, EBUSY) is surfaced as :class:`HostsError` so callers degrade
+    gracefully instead of crashing on a raw ``OSError``."""
+    try:
+        mode = path.stat().st_mode & 0o777 if path.exists() else 0o644
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".avai-hosts-")
+    except OSError as e:
+        raise HostsError(f"could not update {path}: {e}") from e
     try:
         with os.fdopen(fd, "w", encoding="utf-8", newline="") as handle:
             handle.write(text)
@@ -242,6 +250,16 @@ def _atomic_write(path: Path, text: str) -> None:
             os.fsync(handle.fileno())
         os.chmod(tmp, mode)
         os.replace(tmp, path)
+    except OSError as e:
+        # The target can be unwritable for reasons beyond privilege — e.g. in a
+        # container /etc/hosts is a bind-mounted file, so os.replace() onto it
+        # fails with EBUSY. Surface as HostsError so callers (the dashboard
+        # banner, `install-hosts`) degrade gracefully instead of crashing.
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise HostsError(f"could not update {path}: {e}") from e
     except BaseException:
         try:
             os.unlink(tmp)

--- a/tests/test_hostsfile.py
+++ b/tests/test_hostsfile.py
@@ -254,16 +254,20 @@ def test_atomic_write_replaces_content(tmp_path):
     assert [p.name for p in tmp_path.iterdir()] == ["hosts"]
 
 
-def test_atomic_write_leaves_no_temp_on_failure(tmp_path, monkeypatch):
+def test_atomic_write_wraps_os_error_and_cleans_up(tmp_path, monkeypatch):
+    """A failing os.replace (e.g. EBUSY on a container's bind-mounted
+    /etc/hosts) is surfaced as HostsError — not a raw OSError that would
+    crash the dashboard — and the temp file is cleaned up."""
     from avai import hostsfile
 
     target = tmp_path / "hosts"
     target.write_text("old\n")
 
     def _boom(*_a, **_k):
-        raise OSError("disk full")
+        raise OSError(16, "Device or resource busy")
 
     monkeypatch.setattr(os, "replace", _boom)
-    with pytest.raises(OSError):
+    with pytest.raises(hostsfile.HostsError):
         hostsfile._atomic_write(target, "new\n")
     assert [p.name for p in tmp_path.iterdir()] == ["hosts"]  # temp cleaned up
+    assert target.read_text() == "old\n"  # original untouched

--- a/web/components/landing/Hero.tsx
+++ b/web/components/landing/Hero.tsx
@@ -11,7 +11,7 @@ export function Hero() {
   return (
     <section className="mx-auto max-w-6xl px-6 pt-16 pb-12 text-center">
       <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-300">
-        <span className="pulse-dot" /> v0.7.0 — open source, MIT licensed
+        <span className="pulse-dot" /> v0.7.1 — open source, MIT licensed
       </span>
       <h1 className="mx-auto mt-6 max-w-3xl text-4xl font-bold leading-tight sm:text-5xl">
         <span className="grad-text">


### PR DESCRIPTION
Default `docker run -p 8765:8765 -v "$PWD":/data iklob1/avai` now runs **both** the monitor and the dashboard under supervisord, so the dashboard is populated out of the box. They share `/data/avai.db` (monitor writes, dashboard reads live); supervisord auto-restarts either role; single-role override preserved (`avai dashboard` / `avai monitor`).

**Fix:** dashboard crashed in-container because the avai.local hosts mapping did `os.replace()` onto the bind-mounted `/etc/hosts` (EBUSY). `_atomic_write` now wraps OS write failures as `HostsError` → graceful degrade (regression test added).

Verified locally: built the image, ran the exact command, confirmed both processes via `docker top`, container healthy, dashboard serves the monitor's live data, supervisord auto-restarted a crashed child. 143 tests pass; ruff clean; web tsc clean.