### PR TITLE
v0.7.2 — document YARA file scanning (landing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to **avai** (PyPI: `avai-monitor`, Docker:
 `iklob1/avai`). Versions follow semantic versioning.
 
+## [0.7.2] — 2026-06-18
+
+### Added
+- **Landing page: the built-in YARA file-scanning feature, documented.** A new feature card and an explainer callout describe the integration — avai compiles a YARA ruleset (a small bundled set plus optional public packs: signature-base, YARA-Forge), scans on-disk executables and recently-changed Downloads locally each cycle, and runs every match through the same LLM judge so a hit becomes a plain-English verdict (rule, file path, author) in the File Scan panel.
+
+_Docs/landing only — no functional change to the Python package or Docker image since 0.7.1._
+
 ## [0.7.1] — 2026-06-17
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 # differs, because the canonical `avai` slot is blocked by PyPI's
 # name-similarity policy.
 name = "avai-monitor"
-version = "0.7.1"
+version = "0.7.2"
 description = "macOS / Linux host-security telemetry collector with an LLM threat judge and a single-page web dashboard."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/avai/__init__.py
+++ b/src/avai/__init__.py
@@ -13,4 +13,4 @@ Or programmatically:
     from avai.dashboard import app as dashboard_app
 """
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/web/components/landing/Hero.tsx
+++ b/web/components/landing/Hero.tsx
@@ -11,7 +11,7 @@ export function Hero() {
   return (
     <section className="mx-auto max-w-6xl px-6 pt-16 pb-12 text-center">
       <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-300">
-        <span className="pulse-dot" /> v0.7.1 — open source, MIT licensed
+        <span className="pulse-dot" /> v0.7.2 — open source, MIT licensed
       </span>
       <h1 className="mx-auto mt-6 max-w-3xl text-4xl font-bold leading-tight sm:text-5xl">
         <span className="grad-text">


### PR DESCRIPTION
Version bump to 0.7.2 for the YARA landing feature already merged in #29, keeping the tag / PyPI / Docker aligned. Package and image are functionally identical to 0.7.1 (landing-only change).