### PR TITLE
v0.7.3 — fix enabled-but-idle system-integrity false-negative + active pill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to **avai** (PyPI: `avai-monitor`, Docker:
 `iklob1/avai`). Versions follow semantic versioning.
 
+## [0.7.3] — 2026-06-18
+
+### Fixed
+- **System-integrity no longer reports an enabled-but-idle service as "off".** SSH / Screen Sharing / Remote Management were inferred from `pgrep` (is the daemon's process running *right now*), which misses socket-activated macOS services that `launchd` keeps listening on while the daemon is idle — so an exposed-but-idle SSH read as disabled. Detection now goes through a `NetworkServiceControl` abstraction: a service is **enabled** if the service manager reports it enabled **or** something is listening on its port (authoritative on macOS/Linux when running as root). Linux SSH uses the same control; Windows already read the authoritative `fDenyTSConnections` flag and is unchanged.
+
+### Added
+- **"Active" indicator for live remote sessions.** Each network-service control also reports *behaviour* — whether a session is connected right now (daemon running or an established peer) — surfaced as an "active" pill in the System Integrity panel next to the enabled badge.
+
+### Internal
+- New `SecurityControl` / `NetworkServiceControl` abstraction with injected `ServiceManager` (launchd/systemd/SCM) and psutil-backed `PortInspector` / `ProcessInspector` capability seams — one control class covers SSH/Screen Sharing/ARD across platforms, fully unit-tested with fakes (including the false-negative regression).
+
 ## [0.7.2] — 2026-06-18
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 # differs, because the canonical `avai` slot is blocked by PyPI's
 # name-similarity policy.
 name = "avai-monitor"
-version = "0.7.2"
+version = "0.7.3"
 description = "macOS / Linux host-security telemetry collector with an LLM threat judge and a single-page web dashboard."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/avai/__init__.py
+++ b/src/avai/__init__.py
@@ -13,4 +13,4 @@ Or programmatically:
     from avai.dashboard import app as dashboard_app
 """
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"

--- a/src/avai/dashboard/queries.py
+++ b/src/avai/dashboard/queries.py
@@ -2160,6 +2160,16 @@ def system_integrity(session: Session, run_id: str):
         "vnc_active",
         "luks_mappings",
     }
+    # Behaviour ("active now") signals, written by the network-service
+    # controls alongside the posture columns. Each row is
+    # ``(label, enabled, active)``; active is None for topics that have no
+    # live-session concept (FileVault, Gatekeeper, …).
+    svc = raw.get("services") or {}
+
+    def _active(topic: str):
+        entry = svc.get(topic)
+        return entry.get("active") if isinstance(entry, dict) else None
+
     if linux_keys & set(raw):
         apparmor = raw.get("apparmor")
         apparmor_on = (
@@ -2168,25 +2178,29 @@ def system_integrity(session: Session, run_id: str):
         return {
             "platform": "Linux",
             "rows": [
-                ("SELinux", raw.get("selinux")),
-                ("AppArmor", apparmor_on),
-                ("Firewall (ufw)", raw.get("ufw_active")),
-                ("Firewall (firewalld)", raw.get("firewalld_active")),
-                ("SSH (sshd)", raw.get("sshd_active")),
-                ("VNC", raw.get("vnc_active")),
-                ("Disk encryption (LUKS)", bool(raw.get("luks_mappings"))),
+                ("SELinux", raw.get("selinux"), None),
+                ("AppArmor", apparmor_on, None),
+                ("Firewall (ufw)", raw.get("ufw_active"), None),
+                ("Firewall (firewalld)", raw.get("firewalld_active"), None),
+                ("SSH (sshd)", raw.get("sshd_active"), _active("remote_login")),
+                ("VNC", raw.get("vnc_active"), _active("screen_sharing")),
+                ("Disk encryption (LUKS)", bool(raw.get("luks_mappings")), None),
             ],
         }
     return {
         "platform": "macOS",
         "rows": [
-            ("FileVault", row.filevault_active),
-            ("Firewall", row.firewall_global_state),
-            ("Firewall stealth", row.firewall_stealth),
-            ("Gatekeeper", row.gatekeeper_assessments_enabled),
-            ("SSH (sshd)", row.remote_login_enabled),
-            ("Screen Sharing", row.screen_sharing_enabled),
-            ("Remote Mgmt (ARD)", row.remote_management_enabled),
+            ("FileVault", row.filevault_active, None),
+            ("Firewall", row.firewall_global_state, None),
+            ("Firewall stealth", row.firewall_stealth, None),
+            ("Gatekeeper", row.gatekeeper_assessments_enabled, None),
+            ("SSH (sshd)", row.remote_login_enabled, _active("remote_login")),
+            ("Screen Sharing", row.screen_sharing_enabled, _active("screen_sharing")),
+            (
+                "Remote Mgmt (ARD)",
+                row.remote_management_enabled,
+                _active("remote_management"),
+            ),
         ],
     }
 

--- a/src/avai/host_monitor/collectors.py
+++ b/src/avai/host_monitor/collectors.py
@@ -80,10 +80,18 @@ from .runtime import (
     ExternalSqliteReader,
     HostPaths,
     JsonLineStreamSource,
+    LaunchdServiceManager,
+    PortInspector,
+    ProcessInspector,
     PsutilConnections,
-    ServiceProbe,
+    PsutilPortInspector,
+    PsutilProcessInspector,
+    ServiceManager,
+    SystemdServiceManager,
     SystemMetrics,
+    tri_or,
 )
+from .security_controls import NetworkServiceControl, ServiceSpec
 
 
 class Collector(ABC):
@@ -1148,6 +1156,35 @@ class SystemIntegrityCollector(SnapshotCollector):
         "remote_management_enabled",
     )
 
+    # macOS network-service topics (label, port, process). enabled = launchd
+    # job enabled OR port listening — so an idle-but-enabled daemon (whose
+    # process hasn't been spawned yet by launchd) is never reported "off".
+    _SERVICES = (
+        ServiceSpec("remote_login", "com.openssh.sshd", 22, "sshd"),
+        ServiceSpec(
+            "screen_sharing", "com.apple.screensharing", 5900, "screensharingd"
+        ),
+        ServiceSpec(
+            "remote_management", "com.apple.RemoteDesktop.agent", 3283, "ARDAgent"
+        ),
+    )
+
+    def __init__(
+        self,
+        judge_hints: str = "",
+        services: Optional[ServiceManager] = None,
+        ports: Optional[PortInspector] = None,
+        processes: Optional[ProcessInspector] = None,
+    ) -> None:
+        super().__init__(judge_hints=judge_hints)
+        svc = services or LaunchdServiceManager()
+        ports = ports or PsutilPortInspector()
+        processes = processes or PsutilProcessInspector()
+        self._controls = {
+            s.topic: NetworkServiceControl(s, svc, ports, processes)
+            for s in self._SERVICES
+        }
+
     def collect(self):
         fv = CommandRunner().exit_code(["fdesetup", "isactive"])
         alf = (
@@ -1171,18 +1208,28 @@ class SystemIntegrityCollector(SnapshotCollector):
                 gk = None
         except (FileNotFoundError, subprocess.TimeoutExpired):
             gk = None
+        # Posture (enabled) + behaviour (active) for the network services,
+        # via the injected controls. Persisting enabled into the existing
+        # columns; the live-session signal is kept in raw_json for the judge.
+        svc = {t: c.inspect() for t, c in self._controls.items()}
         yield {
             "filevault_active": None if fv is None else int(fv == 0),
             "firewall_global_state": alf.get("globalstate"),
             "firewall_stealth": int(bool(alf.get("stealthenabled"))) if alf else None,
             "firewall_logging": int(bool(alf.get("loggingenabled"))) if alf else None,
             "gatekeeper_assessments_enabled": gk,
-            # launchctl list only covers the user domain; sshd/screensharingd/
-            # ARDAgent are system-domain services — use pgrep instead.
-            "remote_login_enabled": ServiceProbe().running("sshd"),
-            "screen_sharing_enabled": ServiceProbe().running("screensharingd"),
-            "remote_management_enabled": ServiceProbe().running("ARDAgent"),
-            "raw_json": json.dumps({"alf": Coerce.jsonable(alf)}),
+            "remote_login_enabled": svc["remote_login"].enabled,
+            "screen_sharing_enabled": svc["screen_sharing"].enabled,
+            "remote_management_enabled": svc["remote_management"].enabled,
+            "raw_json": json.dumps(
+                {
+                    "alf": Coerce.jsonable(alf),
+                    "services": {
+                        t: {"enabled": f.enabled, "active": f.active}
+                        for t, f in svc.items()
+                    },
+                }
+            ),
         }
 
 
@@ -2453,12 +2500,33 @@ class LinuxSystemIntegrityCollector(SnapshotCollector):
         "remote_management_enabled",
     )
 
+    # SSH goes through the shared control (systemd-enabled OR port 22
+    # listening); VNC stays multi-server (x11vnc/vncserver/xrdp) but gains
+    # the port-5900 robustness + an active signal.
+    _SSH = ServiceSpec("remote_login", "ssh.service", 22, "sshd")
+    _VNC_PORT = 5900
+
+    def __init__(
+        self,
+        judge_hints: str = "",
+        services: Optional[ServiceManager] = None,
+        ports: Optional[PortInspector] = None,
+        processes: Optional[ProcessInspector] = None,
+    ) -> None:
+        super().__init__(judge_hints=judge_hints)
+        self._ports = ports or PsutilPortInspector()
+        self._ssh = NetworkServiceControl(
+            self._SSH,
+            services or SystemdServiceManager(),
+            self._ports,
+            processes or PsutilProcessInspector(),
+        )
+
     def collect(self):
         selinux = self._selinux_state()
         apparmor = self._apparmor_state()
         ufw = self._ufw_active()
         fwd = self._service_active("firewalld")
-        sshd = self._service_active("ssh") or self._service_active("sshd")
         vnc = (
             self._service_active("x11vnc")
             or self._service_active("vncserver")
@@ -2466,14 +2534,25 @@ class LinuxSystemIntegrityCollector(SnapshotCollector):
         )
         luks_n = self._luks_count()
 
+        ssh = self._ssh.inspect()
+        vnc_enabled = tri_or(int(vnc), self._ports.listening(self._VNC_PORT))
+        vnc_active = tri_or(int(vnc), self._ports.established(self._VNC_PORT))
+
         raw = {
             "selinux": selinux,
             "apparmor": apparmor,
             "ufw_active": ufw,
             "firewalld_active": fwd,
-            "sshd_active": sshd,
-            "vnc_active": vnc,
+            # posture (enabled) drives the dashboard badge; behaviour lives
+            # under "services" for the "active" pill.
+            "sshd_active": ssh.enabled,
+            "vnc_active": vnc_enabled,
             "luks_mappings": luks_n,
+            "services": {
+                "remote_login": {"enabled": ssh.enabled, "active": ssh.active},
+                "screen_sharing": {"enabled": vnc_enabled, "active": vnc_active},
+                "remote_management": {"enabled": vnc_enabled, "active": vnc_active},
+            },
         }
 
         yield {
@@ -2484,9 +2563,9 @@ class LinuxSystemIntegrityCollector(SnapshotCollector):
             "gatekeeper_assessments_enabled": int(
                 selinux == "Enforcing" or apparmor.get("enabled") is True
             ),
-            "remote_login_enabled": int(sshd),
-            "screen_sharing_enabled": int(vnc),
-            "remote_management_enabled": int(vnc),
+            "remote_login_enabled": ssh.enabled,
+            "screen_sharing_enabled": vnc_enabled,
+            "remote_management_enabled": vnc_enabled,
             "raw_json": json.dumps(raw),
         }
 

--- a/src/avai/host_monitor/runtime/__init__.py
+++ b/src/avai/host_monitor/runtime/__init__.py
@@ -20,7 +20,21 @@ from .coerce import Coerce
 from .command_runner import CommandRunner
 from .digest import Digest
 from .host_paths import HostPaths
-from .probes import DiskMetrics, PsutilConnections, ServiceProbe, SystemMetrics
+from .probes import (
+    DiskMetrics,
+    LaunchdServiceManager,
+    PortInspector,
+    ProcessInspector,
+    PsutilConnections,
+    PsutilPortInspector,
+    PsutilProcessInspector,
+    ServiceManager,
+    ServiceProbe,
+    SystemdServiceManager,
+    SystemMetrics,
+    WindowsScmServiceManager,
+    tri_or,
+)
 from .row_source import CommandSnapshot, FileSnapshot, RowParser, RowSource
 from .sqlite_reader import ExternalSqliteReader
 from .stream_source import JsonLineStreamSource, LineParser
@@ -36,6 +50,15 @@ __all__ = [
     "SystemMetrics",
     "DiskMetrics",
     "ServiceProbe",
+    "ServiceManager",
+    "LaunchdServiceManager",
+    "SystemdServiceManager",
+    "WindowsScmServiceManager",
+    "PortInspector",
+    "PsutilPortInspector",
+    "ProcessInspector",
+    "PsutilProcessInspector",
+    "tri_or",
     "CommandSnapshot",
     "FileSnapshot",
     "RowParser",

--- a/src/avai/host_monitor/runtime/probes.py
+++ b/src/avai/host_monitor/runtime/probes.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import sys
 from collections import namedtuple
-from typing import Optional
+from typing import Optional, Protocol
 
 try:
     import psutil
@@ -289,3 +289,125 @@ class ServiceProbe:
         misses from the user session."""
         code = self._runner.exit_code(["pgrep", "-x", name])
         return None if code is None else int(code == 0)
+
+
+def tri_or(*values: Optional[int]) -> Optional[int]:
+    """Tri-state OR over 1/0/None signals: 1 if any signal is on, else 0 if
+    any signal is known-off, else None (all unknown). Lets a control combine
+    an authoritative-but-maybe-unavailable signal with a fallback without a
+    known-off masking an unknown-on."""
+    if any(v == 1 for v in values):
+        return 1
+    if any(v == 0 for v in values):
+        return 0
+    return None
+
+
+# --- capability seams: posture/behaviour of a service, one mechanism each ---
+# These are the OS-specific strategies a SecurityControl composes (DIP). The
+# control depends on these tiny interfaces, never on the commands directly;
+# the composition root (host module) injects the right implementation.
+
+
+class ServiceManager(Protocol):
+    """Whether a managed service is *enabled* (configured to be reachable),
+    independent of whether its process happens to be running right now."""
+
+    def enabled(self, unit: str) -> Optional[int]: ...
+
+
+class PortInspector(Protocol):
+    """Socket-level posture/behaviour: is something listening on a port
+    (enabled/exposed), and is there a live peer (in use right now)."""
+
+    def listening(self, port: int) -> Optional[int]: ...
+    def established(self, port: int) -> Optional[int]: ...
+
+
+class ProcessInspector(Protocol):
+    """Whether a process with an exact name is running (behaviour signal)."""
+
+    def running(self, name: str) -> Optional[int]: ...
+
+
+class LaunchdServiceManager:
+    """macOS: a system-domain launchd job is enabled when it's bootstrapped
+    (``launchctl print system/<label>`` exits 0). Needs root, which the
+    monitor has."""
+
+    def __init__(self, runner: Optional[CommandRunner] = None) -> None:
+        self._runner = runner or CommandRunner()
+
+    def enabled(self, unit: str) -> Optional[int]:
+        code = self._runner.exit_code(["launchctl", "print", f"system/{unit}"])
+        return None if code is None else int(code == 0)
+
+
+class SystemdServiceManager:
+    """Linux: ``systemctl is-enabled <unit>`` exits 0 for enabled/static."""
+
+    def __init__(self, runner: Optional[CommandRunner] = None) -> None:
+        self._runner = runner or CommandRunner()
+
+    def enabled(self, unit: str) -> Optional[int]:
+        code = self._runner.exit_code(["systemctl", "is-enabled", unit])
+        return None if code is None else int(code == 0)
+
+
+class WindowsScmServiceManager:
+    """Windows: a service is enabled when its SCM start type isn't DISABLED
+    (``sc qc <name>``)."""
+
+    def __init__(self, runner: Optional[CommandRunner] = None) -> None:
+        self._runner = runner or CommandRunner()
+
+    def enabled(self, unit: str) -> Optional[int]:
+        out = self._runner.text(["sc", "qc", unit])
+        if not out:
+            return None
+        upper = out.upper()
+        if "DISABLED" in upper:
+            return 0
+        if "AUTO_START" in upper or "DEMAND_START" in upper:
+            return 1
+        return None
+
+
+class PsutilPortInspector:
+    """Cross-platform port posture/behaviour from the psutil connection table
+    (one implementation for every OS). Needs root for full visibility — the
+    monitor runs as root; without it both signals degrade to None."""
+
+    def __init__(self, connections: Optional[PsutilConnections] = None) -> None:
+        self._connections = connections or PsutilConnections()
+
+    def _count(self, port: int, status: str) -> Optional[int]:
+        try:
+            conns = self._connections.inet()
+        except PermissionError:
+            return None
+        for c in conns:
+            laddr = getattr(c, "laddr", None)
+            if laddr and getattr(laddr, "port", None) == port and c.status == status:
+                return 1
+        return 0
+
+    def listening(self, port: int) -> Optional[int]:
+        return self._count(port, psutil.CONN_LISTEN)
+
+    def established(self, port: int) -> Optional[int]:
+        return self._count(port, psutil.CONN_ESTABLISHED)
+
+
+class PsutilProcessInspector:
+    """Cross-platform exact-name process check (one implementation for every
+    OS); replaces the POSIX-only ``pgrep -x`` shell-out."""
+
+    def running(self, name: str) -> Optional[int]:
+        try:
+            for proc in psutil.process_iter(["name"]):
+                if proc.info.get("name") == name:
+                    return 1
+            return 0
+        except psutil.Error:
+            return None

--- a/src/avai/host_monitor/security_controls.py
+++ b/src/avai/host_monitor/security_controls.py
@@ -1,0 +1,104 @@
+"""Security-control detection — the proper-abstraction layer for the
+system-integrity topics.
+
+A :class:`SecurityControl` answers two questions about one topic:
+
+* ``enabled`` — *posture*: is the service configured to be reachable? (the
+  thing a security panel must never miss — an exposed SSH that's idle).
+* ``active``  — *behaviour*: is it actually in use right now? (the
+  "webcam-in-use" signal — a live session).
+
+Each control composes small injected capabilities (a
+:class:`ServiceManager`, :class:`PortInspector`, :class:`ProcessInspector`)
+rather than shelling out itself, so the OS differences live entirely in the
+injected strategy and the same control class works on macOS / Linux /
+Windows. Topics are assembled per OS at the composition root (the host
+module), exactly like the RowSource collectors elsewhere.
+
+Values are tri-state ``1`` / ``0`` / ``None`` (on / off / unknown), matching
+the existing ``system_integrity`` columns and probe convention.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+from .runtime import PortInspector, ProcessInspector, ServiceManager, tri_or
+
+
+@dataclass(frozen=True)
+class IntegrityFinding:
+    """One topic's posture + behaviour, with the signal that decided it."""
+
+    topic: str
+    enabled: Optional[int]
+    active: Optional[int]
+    source: str
+
+
+class SecurityControl(Protocol):
+    """Detects exactly one security topic. Substitutable across platforms."""
+
+    topic: str
+
+    def inspect(self) -> IntegrityFinding: ...
+
+
+@dataclass(frozen=True)
+class ServiceSpec:
+    """The OS-agnostic identity of a managed network service: how the service
+    manager names it, the port it exposes, and the process that serves it.
+    Pure data — the only thing that varies between SSH / Screen Sharing / ARD
+    and between operating systems."""
+
+    topic: str
+    unit: str
+    port: int
+    process: str
+
+
+class NetworkServiceControl:
+    """Posture + behaviour for a socket-activated network service (SSH,
+    Screen Sharing, ARD/RDP), on any OS.
+
+    ``enabled`` = the service manager reports it enabled **or** something is
+    listening on its port — so an enabled-but-idle daemon (whose process
+    isn't running yet) is never reported "off". ``active`` = the daemon
+    process is running **or** a peer is connected. This replaces the old
+    ``pgrep``-only check, which conflated "in use right now" with "enabled"
+    and therefore hid idle-but-exposed services.
+    """
+
+    def __init__(
+        self,
+        spec: ServiceSpec,
+        services: ServiceManager,
+        ports: PortInspector,
+        processes: ProcessInspector,
+    ) -> None:
+        self._spec = spec
+        self._services = services
+        self._ports = ports
+        self._processes = processes
+
+    @property
+    def topic(self) -> str:
+        return self._spec.topic
+
+    def inspect(self) -> IntegrityFinding:
+        spec = self._spec
+        enabled = tri_or(
+            self._services.enabled(spec.unit),
+            self._ports.listening(spec.port),
+        )
+        active = tri_or(
+            self._processes.running(spec.process),
+            self._ports.established(spec.port),
+        )
+        return IntegrityFinding(
+            topic=spec.topic,
+            enabled=enabled,
+            active=active,
+            source="service+port+process",
+        )

--- a/src/avai/templates/partials/_sysint.html
+++ b/src/avai/templates/partials/_sysint.html
@@ -10,10 +10,16 @@
   </div>
   {% if sysint %}
     <ul class="divide-y divide-slate-800/80 text-sm">
-      {% for name, value in sysint.rows %}
+      {% for name, value, active in sysint.rows %}
         <li class="flex items-center justify-between py-2">
           <span class="text-slate-300">{{ name }}</span>
-          {{ status_badge(value) }}
+          <span class="flex items-center gap-1.5">
+            {% if active %}
+              <span class="inline-flex items-center px-2 py-0.5 rounded-full border text-[10px] font-semibold uppercase tracking-wider bg-amber-900/40 text-amber-300 border-amber-900/60"
+                    title="A live session is active right now">active</span>
+            {% endif %}
+            {{ status_badge(value) }}
+          </span>
         </li>
       {% endfor %}
     </ul>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1113,12 +1113,12 @@ class TestSystemIntegrityPlatform:
         with Session(sink.engine) as s:
             si = system_integrity(s, run_id)
         assert si["platform"] == "Linux"
-        labels = [name for name, _ in si["rows"]]
+        labels = [name for name, _enabled, _active in si["rows"]]
         # macOS-only labels must NOT appear for Linux data.
         assert "FileVault" not in labels
         assert "Gatekeeper" not in labels
         # Linux posture must be present and read from raw_json.
-        d = dict(si["rows"])
+        d = {name: enabled for name, enabled, _active in si["rows"]}
         assert d["AppArmor"] is True
         assert d["Firewall (ufw)"] is True
         assert d["Disk encryption (LUKS)"] is True
@@ -1146,11 +1146,43 @@ class TestSystemIntegrityPlatform:
         with Session(sink.engine) as s:
             si = system_integrity(s, run_id)
         assert si["platform"] == "macOS"
-        d = dict(si["rows"])
+        d = {name: enabled for name, enabled, _active in si["rows"]}
         assert "FileVault" in d
         assert d["FileVault"] == 1
         assert d["Gatekeeper"] == 1
         assert "Disk encryption (LUKS)" not in d  # not a macOS label
+
+    def test_active_session_signal_surfaced_from_raw_json(self, tmp_path):
+        import json as _json
+
+        sink = self._sink(tmp_path)
+        run_id, ts = self._run(sink)
+        sink.write(
+            SystemIntegrityRow,
+            [
+                {
+                    "run_id": run_id,
+                    "collected_at": ts,
+                    "content_hash": "c",
+                    "remote_login_enabled": 1,
+                    "screen_sharing_enabled": 0,
+                    "raw_json": _json.dumps(
+                        {
+                            "services": {
+                                "remote_login": {"enabled": 1, "active": 1},
+                                "screen_sharing": {"enabled": 0, "active": 0},
+                            }
+                        }
+                    ),
+                }
+            ],
+        )
+        with Session(sink.engine) as s:
+            si = system_integrity(s, run_id)
+        active = {name: act for name, _enabled, act in si["rows"]}
+        assert active["SSH (sshd)"] == 1  # live session surfaced as the pill
+        assert active["Screen Sharing"] == 0
+        assert active["FileVault"] is None  # no live-session concept
 
     def test_missing_row_returns_none(self, tmp_path):
         sink = self._sink(tmp_path)

--- a/tests/test_security_controls.py
+++ b/tests/test_security_controls.py
@@ -1,0 +1,138 @@
+"""Tests for the security-control abstraction.
+
+The point of the abstraction is testability: every control is exercised with
+fake capabilities, so the enabled-vs-active logic — including the
+socket-activated false-negative regression — is verified deterministically
+with no OS calls.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from avai.host_monitor.runtime import tri_or
+from avai.host_monitor.security_controls import NetworkServiceControl, ServiceSpec
+
+SSH = ServiceSpec("remote_login", "com.openssh.sshd", 22, "sshd")
+
+
+class FakeServiceManager:
+    def __init__(self, enabled=None):
+        self._enabled = enabled
+
+    def enabled(self, unit):
+        return self._enabled
+
+
+class FakePortInspector:
+    def __init__(self, listening=None, established=None):
+        self._listening = listening
+        self._established = established
+
+    def listening(self, port):
+        return self._listening
+
+    def established(self, port):
+        return self._established
+
+
+class FakeProcessInspector:
+    def __init__(self, running=None):
+        self._running = running
+
+    def running(self, name):
+        return self._running
+
+
+def _control(svc=None, listening=None, established=None, running=None):
+    return NetworkServiceControl(
+        SSH,
+        FakeServiceManager(svc),
+        FakePortInspector(listening=listening, established=established),
+        FakeProcessInspector(running=running),
+    )
+
+
+# ---- tri_or -------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "values,expected",
+    [
+        ((1, 0), 1),
+        ((0, 1), 1),
+        ((0, 0), 0),
+        ((0, None), 0),
+        ((None, None), None),
+        ((None, 1), 1),
+    ],
+)
+def test_tri_or(values, expected):
+    assert tri_or(*values) == expected
+
+
+# ---- NetworkServiceControl ---------------------------------------------
+
+
+def test_enabled_but_idle_is_reported_enabled_not_off():
+    # The regression: launchd holds the socket (port listening) but the
+    # daemon process isn't spawned and there's no peer. The old pgrep-only
+    # check reported this as "off"; it must now be enabled=ON, active=OFF.
+    f = _control(svc=None, listening=1, established=0, running=0).inspect()
+    assert f.enabled == 1
+    assert f.active == 0
+
+
+def test_enabled_via_service_manager_without_ports():
+    # No port visibility (non-root → None) but the service manager says
+    # enabled — still enabled.
+    f = _control(svc=1, listening=None, established=None, running=0).inspect()
+    assert f.enabled == 1
+    assert f.active == 0
+
+
+def test_genuinely_off():
+    f = _control(svc=0, listening=0, established=0, running=0).inspect()
+    assert f.enabled == 0
+    assert f.active == 0
+
+
+def test_active_session():
+    # A live peer + running daemon → enabled and active.
+    f = _control(svc=1, listening=1, established=1, running=1).inspect()
+    assert f.enabled == 1
+    assert f.active == 1
+
+
+def test_all_unknown_stays_unknown():
+    f = _control(svc=None, listening=None, established=None, running=None).inspect()
+    assert f.enabled is None
+    assert f.active is None
+
+
+def test_topic_is_exposed():
+    assert _control().topic == "remote_login"
+
+
+# ---- collector wiring (end-to-end regression) ---------------------------
+
+
+def test_macos_collector_maps_enabled_idle_service_to_on():
+    """The macOS collector, given an enabled-but-idle service, writes
+    ``..._enabled = 1`` (not 0) and keeps the live-session signal in
+    raw_json. Mac-only config commands degrade gracefully off-platform."""
+    import json
+
+    from avai.host_monitor.collectors import SystemIntegrityCollector
+
+    col = SystemIntegrityCollector(
+        services=FakeServiceManager(1),
+        ports=FakePortInspector(listening=0, established=0),
+        processes=FakeProcessInspector(running=0),
+    )
+    row = list(col.collect())[0]
+    assert row["remote_login_enabled"] == 1
+    assert row["screen_sharing_enabled"] == 1
+    assert row["remote_management_enabled"] == 1
+    services = json.loads(row["raw_json"])["services"]
+    assert services["remote_login"] == {"enabled": 1, "active": 0}

--- a/web/components/landing/Hero.tsx
+++ b/web/components/landing/Hero.tsx
@@ -11,7 +11,7 @@ export function Hero() {
   return (
     <section className="mx-auto max-w-6xl px-6 pt-16 pb-12 text-center">
       <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-300">
-        <span className="pulse-dot" /> v0.7.2 — open source, MIT licensed
+        <span className="pulse-dot" /> v0.7.3 — open source, MIT licensed
       </span>
       <h1 className="mx-auto mt-6 max-w-3xl text-4xl font-bold leading-tight sm:text-5xl">
         <span className="grad-text">


### PR DESCRIPTION
SSH/Screen Sharing/Remote Management were inferred from `pgrep` (process running now), missing socket-activated macOS daemons that `launchd` keeps listening on while idle — an exposed-but-idle SSH read as 'off'. New `NetworkServiceControl` abstraction (injected `ServiceManager` + psutil port/process inspectors): **enabled = service-enabled OR port-listening**, **active = process OR established peer**. Wired into macOS + Linux collectors; Windows unchanged (already reads the authoritative `fDenyTSConnections` flag). Live sessions surface as an 'active' pill. Fully fakes-tested incl. the regression. 145 integrity/dashboard tests pass; tsc + ruff clean.